### PR TITLE
Ensure CMS categories respect shop context

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -2026,7 +2026,14 @@ class FrontControllerCore extends Controller
         $this->context->smarty->assign(
             [
                 'categoriesTree'            => Category::getRootCategory()->recurseLiteCategTree(0),
-                'categoriescmsTree'         => CMSCategory::getRecurseCategory($this->context->language->id, 1, 1, 1),
+                'categoriescmsTree'         => CMSCategory::getRecurseCategory(
+                    $this->context->language->id,
+                    1,
+                    1,
+                    1,
+                    null,
+                    $this->context->shop->id
+                ),
                 'voucherAllowed'            => (int) CartRule::isFeatureActive(),
                 'display_manufacturer_link' => (bool) $blockmanufacturer->active,
                 'display_supplier_link'     => (bool) $blocksupplier->active,

--- a/controllers/admin/AdminCmsCategoriesController.php
+++ b/controllers/admin/AdminCmsCategoriesController.php
@@ -247,7 +247,12 @@ class AdminCmsCategoriesControllerCore extends AdminController
             return null;
         }
 
-        $categories = CMSCategory::getCategories($this->context->language->id, false);
+        $categories = CMSCategory::getCategories(
+            $this->context->language->id,
+            false,
+            true,
+            $this->context->shop->id
+        );
         $htmlCategories = CMSCategory::recurseCMSCategory($categories, $categories[0][1], 1, $this->getFieldValue($this->object, 'id_parent'), 1);
 
         $this->fields_form = [

--- a/controllers/admin/AdminCmsController.php
+++ b/controllers/admin/AdminCmsController.php
@@ -143,7 +143,12 @@ class AdminCmsControllerCore extends AdminController
         $this->initToolbar();
         $this->initPageHeaderToolbar();
 
-        $categories = CMSCategory::getCategories($this->context->language->id, false);
+        $categories = CMSCategory::getCategories(
+            $this->context->language->id,
+            false,
+            true,
+            $this->context->shop->id
+        );
         $htmlCategories = CMSCategory::recurseCMSCategory($categories, $categories[0][1], 1, $this->getFieldValue($this->object, 'id_cms_category'), 1);
 
         $this->fields_form = [

--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -66,7 +66,14 @@ class SitemapControllerCore extends FrontController
         parent::initContent();
 
         $this->context->smarty->assign('categoriesTree', Category::getRootCategory()->recurseLiteCategTree(0));
-        $this->context->smarty->assign('categoriescmsTree', CMSCategory::getRecurseCategory($this->context->language->id, 1, 1, 1));
+        $this->context->smarty->assign('categoriescmsTree', CMSCategory::getRecurseCategory(
+            $this->context->language->id,
+            1,
+            1,
+            1,
+            null,
+            $this->context->shop->id
+        ));
         $this->context->smarty->assign('voucherAllowed', (int) CartRule::isFeatureActive());
 
         if (Module::isInstalled('blockmanufacturer') && Module::isEnabled('blockmanufacturer')) {


### PR DESCRIPTION
## Summary
- add optional `$idShop` parameter to CMS category helpers, defaulting to all shops to preserve backwards compatibility
- join `cms_category_shop` and filter language rows only when a shop ID is supplied, enabling shop-aware queries
- propagate the optional shop ID through recursive category lookups so tree and CMS retrieval respects shop context
- pass the current shop ID from admin and front controllers so CMS listings and sitemaps only include categories linked to that shop

## Testing
- `php -l classes/CMSCategory.php`
- `php -l classes/controller/FrontController.php`
- `php -l controllers/admin/AdminCmsCategoriesController.php`
- `php -l controllers/admin/AdminCmsController.php`
- `php -l controllers/front/SitemapController.php`


------
https://chatgpt.com/codex/tasks/task_e_689a5dbaa288832db2259675d5fb47f7