### PR TITLE
Handle double-quoted strings in translation extractor

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1763,9 +1763,9 @@ class AdminTranslationsControllerCore extends AdminController
             case 'back':
                 // Parsing file in Back office
                 if ($typeFile == 'php') {
-                    $regex = "/this\s*->\s*l\s*\(\s*(\')"._PS_TRANS_PATTERN_."\'\s*[\)|\,]/U";
+                    $regex = "/this\s*->\s*l\s*\(\s*([\'\"])"._PS_TRANS_PATTERN_."\\1\s*[\)|\,]/U";
                 } elseif ($typeFile == 'specific') {
-                    $regex = '/Translate\s*::\s*getAdminTranslation\s*\(\s*(\')'._PS_TRANS_PATTERN_.'\'(?:,.*)*\s*\)/U';
+                    $regex = '/Translate\s*::\s*getAdminTranslation\s*\(\s*([\'\"])'._PS_TRANS_PATTERN_.'\\1(?:,.*)*\s*\)/U';
                 } else {
                     $regex = '/\{\s*l\s*s\s*=([\'\"])'._PS_TRANS_PATTERN_.'\1(\s*sprintf=.*)?(\s*js=1)?(\s*slashes=1)?.*\}/U';
                 }
@@ -1773,15 +1773,16 @@ class AdminTranslationsControllerCore extends AdminController
 
             case 'errors':
                 // Parsing file for all errors syntax
-                $regex = '/Tools\s*::\s*displayError\s*\(\s*(\')'._PS_TRANS_PATTERN_.'\'(,\s*(.+))?\)/U';
+                $regex = '/Tools\s*::\s*displayError\s*\(\s*([\'\"])'._PS_TRANS_PATTERN_.'\\1(,\s*(.+))?\)/U';
                 break;
 
             case 'modules':
                 // Parsing modules file
                 if ($typeFile == 'php') {
                     $regex = [
-                        '/->\s*l\s*\(\s*(\')'._PS_TRANS_PATTERN_.'\'\s*(\s*,\s*?\'(.+)\'\s*)?(,\s*\'(.+)\'\s*)?\)/U',
-                        '/Translate\s*::\s*getModuleTranslation\([^,]*,\s*(\')'._PS_TRANS_PATTERN_.'\'\s*,.*\s*\)/U',
+                        '/->\s*l\s*\(\s*([\'\"])'._PS_TRANS_PATTERN_.'\\1\s*'
+                        .'(\s*,\s*?[\'\"](.+)[\'\"]\s*)?(,\s*[\'\"](.+)[\'\"]\s*)?\)/U',
+                        '/Translate\s*::\s*getModuleTranslation\([^,]*,\s*([\'\"])'._PS_TRANS_PATTERN_.'\\1\s*,.*\s*\)/U',
                     ];
                 } else {
                     // In tpl file look for something that should contain mod='module_name' according to the documentation
@@ -1793,10 +1794,11 @@ class AdminTranslationsControllerCore extends AdminController
                 // Parsing PDF file
                 if ($typeFile == 'php') {
                     $regex = [
-                        '/HTMLTemplate.*::\s*l\s*\(\s*(\')'._PS_TRANS_PATTERN_.'\'\s*[\)|\,]/U',
-                        '/static\s*::\s*l\s*\(\s*(\')'._PS_TRANS_PATTERN_.'\'\s*[\)|\,]/U',
-                        '/Translate\s*::\s*getPdfTranslation\(\s*(\')'._PS_TRANS_PATTERN_.'\'(?:,.*)*\s*\)/U',
-                        '/->\s*l\s*\(\s*(\')'._PS_TRANS_PATTERN_.'\'\s*(\s*,\s*?\'(.+)\'\s*)?(,\s*\'(.+)\'\s*)?\)/U',
+                        '/HTMLTemplate.*::\s*l\s*\(\s*([\'\"])'._PS_TRANS_PATTERN_.'\\1\s*[\)|\,]/U',
+                        '/static\s*::\s*l\s*\(\s*([\'\"])'._PS_TRANS_PATTERN_.'\\1\s*[\)|\,]/U',
+                        '/Translate\s*::\s*getPdfTranslation\(\s*([\'\"])'._PS_TRANS_PATTERN_.'\\1(?:,.*)*\s*\)/U',
+                        '/->\s*l\s*\(\s*([\'\"])'._PS_TRANS_PATTERN_.'\\1\s*'
+                        .'(\s*,\s*?[\'\"](.+)[\'\"]\s*)?(,\s*[\'\"](.+)[\'\"]\s*)?\)/U',
                     ];
                 } else {
                     $regex = '/\{\s*l\s*s\s*=\s*([\'\"])'._PS_TRANS_PATTERN_.'\1(\s*sprintf\s*=\s*.*)?(\s*js\s*=\s*1)?(\s*pdf\s*=\s*\'true\')?(\s*mod\s*=\s*\'[a-zA-Z0-9_]+\')?\s*\}/U';

--- a/tests/Unit/TranslationExtractionTest.php
+++ b/tests/Unit/TranslationExtractionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('AdminController')) {
+    class AdminController {}
+}
+
+if (!defined('_PS_DEFAULT_THEME_NAME_')) {
+    define('_PS_DEFAULT_THEME_NAME_', 'classic');
+}
+
+if (!defined('_PS_TRANS_PATTERN_')) {
+    define('_PS_TRANS_PATTERN_', '(.*[^\\\\])');
+}
+
+require_once __DIR__ . '/../../controllers/admin/AdminTranslationsController.php';
+
+class TranslationExtractionTest extends TestCase
+{
+    public function testExtractsSingleAndDoubleQuotedStrings(): void
+    {
+        $content = '<?php $this->l("double quote"); $this->l(\'single quote\');';
+
+        $refClass = new ReflectionClass(AdminTranslationsControllerCore::class);
+        $controller = $refClass->newInstanceWithoutConstructor();
+        $method = $refClass->getMethod('userParseFile');
+        $method->setAccessible(true);
+        $result = $method->invoke($controller, $content, 'back', 'php');
+
+        $this->assertContains('double quote', $result);
+        $this->assertContains('single quote', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- Allow translation extraction regexes to match both single and double quotes
- Add unit test verifying extraction of double-quoted strings

## Testing
- `phpunit tests/Unit/TranslationExtractionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689efb37a7c4832da32531901c08bc99