### PR TITLE
Send password reset link in guest conversion email

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -997,11 +997,19 @@ class CustomerCore extends ObjectModel
         $this->cleanGroups();
         $this->addGroups([Configuration::get('PS_CUSTOMER_GROUP')]); // add default customer group
         if ($this->update()) {
+            $context = Context::getContext();
+            $url = $context->link->getPageLink(
+                'password',
+                true,
+                null,
+                'token='.$this->secure_key.'&id_customer='.(int) $this->id
+            );
+
             $vars = [
                 '{firstname}' => $this->firstname,
                 '{lastname}'  => $this->lastname,
                 '{email}'     => $this->email,
-                '{passwd}'    => '*******',
+                '{url}'       => $url,
             ];
 
             Mail::Send(

--- a/mails/en/guest_to_customer.html
+++ b/mails/en/guest_to_customer.html
@@ -88,35 +88,27 @@
 							Your customer account creation						</p>
 						<span style="color:#777">
 							Your guest account for <span style="color:#333"><strong>{shop_name}</strong></span> was converted to a customer account. <br /><br />
-							<span style="color:#333"><strong>E-mail address:</strong></span> {email}<br /><br />
-							<span style="color:#333"><strong>Password:</strong></span> ******
-						</span>
-					</font>
-				</td>
-				<td width="10" style="padding:7px 0">&nbsp;</td>
-			</tr>
-		</table>
-	</td>
+                                                        <span style="color:#333"><strong>E-mail address:</strong></span> {email}<br /><br />
+                                                        To set your password, please use the following link:<br /> <a href="{url}" style="color:#337ff1">{url}</a><br /><br />
+                                                </span>
+                                        </font>
+                                </td>
+                                <td width="10" style="padding:7px 0">&nbsp;</td>
+                        </tr>
+                </table>
+        </td>
 </tr>
 <tr>
-	<td class="space_footer" style="padding:0!important">&nbsp;</td>
+        <td class="space_footer" style="padding:0!important">&nbsp;</td>
 </tr>
 <tr>
-	<td class="linkbelow" style="padding:7px 0">
-		<font size="2" face="Open-sans, sans-serif" color="#555454">
-			<span>
-				Please be careful when sharing these login details with others.			</span>
-		</font>
-	</td>
-</tr>
-<tr>
-	<td class="linkbelow" style="padding:7px 0">
-		<font size="2" face="Open-sans, sans-serif" color="#555454">
-			<span>
-				You can access your customer account on our shop: <strong>{shop_url}</strong>
-			</span>
-		</font>
-	</td>
+        <td class="linkbelow" style="padding:7px 0">
+                <font size="2" face="Open-sans, sans-serif" color="#555454">
+                        <span>
+                                You can access your customer account on our shop: <strong>{shop_url}</strong>
+                        </span>
+                </font>
+        </td>
 </tr>
 
 						<tr>

--- a/mails/en/guest_to_customer.txt
+++ b/mails/en/guest_to_customer.txt
@@ -8,9 +8,8 @@ account.
 
 E-MAIL ADDRESS: {email}
 
-PASSWORD: ******
-
-Please be careful when sharing these login details with others.
+To set your password, please use the following link:
+{url}
 
 You can access your customer account on our shop: {shop_url}
 


### PR DESCRIPTION
## Summary
- Drop custom password email helper and generate reset link directly in `Customer::transformToCustomer`
- Embed password reset URL in `guest_to_customer` templates so new customers can set their own password

## Testing
- `php -l classes/Customer.php`
- `php -l controllers/front/PasswordController.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `./vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f7ff4670832d8bd3e70e65d1b1ba