### PR TITLE
Display shop name on customer thread panels

### DIFF
--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/list/list_header.tpl
@@ -33,17 +33,17 @@
 			{assign var=total_thread value=0}
 			{assign var=id_customer_thread value=0}
 
-			{foreach $contacts as $tmp => $tmp2}
-				{if $val.id_contact == $tmp2.id_contact}
-					{assign var=total_thread value=$tmp2.total}
-					{assign var=id_customer_thread value=$tmp2.id_customer_thread}
-				{/if}
-			{/foreach}
+                        {foreach $contacts as $tmp => $tmp2}
+                                {if $val.id_contact == $tmp2.id_contact && $val.id_shop == $tmp2.id_shop}
+                                        {assign var=total_thread value=$tmp2.total}
+                                        {assign var=id_customer_thread value=$tmp2.id_customer_thread}
+                                {/if}
+                        {/foreach}
 			<div class="col-lg-3">
 				<div class="panel">
-					<div class="panel-heading">
-						{$val.name}
-					</div>
+                                        <div class="panel-heading">
+                                                {$val.shop_name} - {$val.name}
+                                        </div>
 					{if $nb_categories < 6}
 						<p>{$val.description}</p>
 					{/if}

--- a/classes/Contact.php
+++ b/classes/Contact.php
@@ -136,13 +136,13 @@ class ContactCore extends ObjectModel
     {
         return Db::readOnly()->getArray(
             (new DbQuery())
-                ->select('cl.*')
+                ->select('cl.*, contact_shop.`id_shop`, s.`name` AS `shop_name`')
                 ->from('contact', 'ct')
                 ->join(Shop::addSqlAssociation('contact', 'ct', false))
                 ->leftJoin('contact_lang', 'cl', 'cl.`id_contact` = ct.`id_contact` AND cl.`id_lang` = '.(int) Context::getContext()->language->id)
+                ->leftJoin('shop', 's', 's.`id_shop` = contact_shop.`id_shop`')
                 ->where('ct.`customer_service` = 1')
-                ->where('contact_shop.`id_shop` IN ('.implode(', ', array_map('intval', Shop::getContextListShopID())).')')
-                ->groupBy('ct.`id_contact`')
+                ->groupBy('ct.`id_contact`, contact_shop.`id_shop`')
         );
     }
 }

--- a/classes/CustomerThread.php
+++ b/classes/CustomerThread.php
@@ -170,14 +170,14 @@ class CustomerThreadCore extends ObjectModel
     {
         return Db::readOnly()->getArray(
             (new DbQuery())
-                ->select('cl.*, COUNT(*) as `total`')
-                ->select('(SELECT `id_customer_thread` FROM `'._DB_PREFIX_.'customer_thread` ct2 WHERE status = "open" AND ct.`id_contact` = ct2.`id_contact` '.Shop::addSqlRestriction().' ORDER BY `date_upd` ASC LIMIT 1) AS `id_customer_thread`')
+                ->select('cl.*, ct.`id_shop`, COUNT(*) as `total`')
+                ->select('(SELECT `id_customer_thread` FROM `'._DB_PREFIX_.'customer_thread` ct2 WHERE status = "open" AND ct.`id_contact` = ct2.`id_contact` AND ct.`id_shop` = ct2.`id_shop` '.Shop::addSqlRestriction(false, 'ct2').' ORDER BY `date_upd` ASC LIMIT 1) AS `id_customer_thread`')
                 ->from('customer_thread', 'ct')
                 ->leftJoin('contact_lang', 'cl', 'cl.`id_contact` = ct.`id_contact` AND cl.`id_lang` = '.(int) Context::getContext()->language->id)
                 ->where('ct.`status` = "open"')
                 ->where('ct.`id_contact` IS NOT NULL')
                 ->where('cl.`id_contact` IS NOT NULL '.Shop::addSqlRestriction())
-                ->groupBy('ct.`id_contact`')
+                ->groupBy('ct.`id_contact`, ct.`id_shop`')
                 ->having('COUNT(*) > 0')
         );
     }


### PR DESCRIPTION
## Summary
- Include shop identifiers and names when fetching customer service contacts
- Prefix customer thread panels with the shop name for clearer multistore context

## Testing
- `php -l classes/CustomerThread.php`
- `php -l classes/Contact.php`
- `./vendor/bin/codecept run Unit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2290af164832daa892b5c4aa0f28b