### PR TITLE
Add asset preload controls for CSS, JS, and fonts

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -491,6 +491,10 @@ class FrontControllerCore extends Controller
             }
         }
 
+        if (Configuration::get('TB_PRELOAD_ASSETS')) {
+            $hookHeader = $this->buildPreloadLinks().$hookHeader;
+        }
+
         // Call hook before assign of css_files and js_files in order to include correctly all css and javascript files
         $this->context->smarty->assign(
             [
@@ -511,6 +515,45 @@ class FrontControllerCore extends Controller
 
         $this->display_header = $display;
         $this->smartyOutputContent(_PS_THEME_DIR_.'header.tpl');
+    }
+
+    /**
+     * Build HTML preload links for registered assets
+     *
+     * @return string
+     */
+    protected function buildPreloadLinks()
+    {
+        $out = '';
+
+        if (!empty($this->css_files) && is_array($this->css_files)) {
+            foreach ($this->css_files as $uri => $media) {
+                $out .= '<link rel="preload" as="style" href="'.Tools::safeOutput($uri).'">' . "\n";
+            }
+        }
+
+        if (!empty($this->js_files) && is_array($this->js_files)) {
+            foreach ($this->js_files as $uri) {
+                $out .= '<link rel="preload" as="script" href="'.Tools::safeOutput($uri).'">' . "\n";
+            }
+        }
+
+        $fonts = trim((string) Configuration::get('TB_PRELOAD_FONT_URLS'));
+        if ($fonts !== '') {
+            foreach (preg_split("/\r?\n/", $fonts) as $font) {
+                $font = trim($font);
+                if ($font === '') {
+                    continue;
+                }
+                $type = (stripos($font, '.woff2') !== false) ? 'font/woff2' : 'font/woff';
+                if ($font[0] === '/' && (strlen($font) < 2 || $font[1] !== '/')) {
+                    $font = Tools::getShopDomainSsl(true).$font;
+                }
+                $out .= '<link rel="preload" as="font" type="'.$type.'" href="'.Tools::safeOutput($font).'" crossorigin>' . "\n";
+            }
+        }
+
+        return $out;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add performance toggles to enable asset preloading and select theme fonts
- generate <link rel="preload"> tags for registered CSS, JS, and chosen fonts

## Testing
- `php -l controllers/admin/AdminPerformanceController.php`
- `php -l classes/controller/FrontController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a256cffee8832d99a03d59b0a82994