### PR TITLE
Add asset preloading configuration and link generation

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -491,6 +491,10 @@ class FrontControllerCore extends Controller
             }
         }
 
+        if ((int) Configuration::get('TB_PRELOAD_ASSETS')) {
+            $hookHeader = $this->buildPreloadLinks() . $hookHeader;
+        }
+
         // Call hook before assign of css_files and js_files in order to include correctly all css and javascript files
         $this->context->smarty->assign(
             [
@@ -511,6 +515,42 @@ class FrontControllerCore extends Controller
 
         $this->display_header = $display;
         $this->smartyOutputContent(_PS_THEME_DIR_.'header.tpl');
+    }
+
+    protected function buildPreloadLinks()
+    {
+        $out = '';
+
+        if (!empty($this->css_files) && is_array($this->css_files)) {
+            foreach ($this->css_files as $uri => $media) {
+                $out .= '<link rel="preload" as="style" href="' . Tools::safeOutput($uri) . '">' . "\n";
+            }
+        }
+
+        if (!empty($this->js_files) && is_array($this->js_files)) {
+            foreach ($this->js_files as $uri) {
+                $out .= '<link rel="preload" as="script" href="' . Tools::safeOutput($uri) . '">' . "\n";
+            }
+        }
+
+        $fonts = trim((string) Configuration::get('TB_PRELOAD_FONT_URLS'));
+        if ($fonts !== '') {
+            foreach (preg_split('~\R+~', $fonts) as $font) {
+                $font = trim($font);
+                if ($font === '') {
+                    continue;
+                }
+                $type = (stripos($font, '.woff2') !== false) ? 'font/woff2' : 'font/woff';
+                if ($font[0] === '/' && strpos($font, '//') !== 1) {
+                    $font = Tools::getShopDomainSsl(true) . $font;
+                } elseif (!preg_match('~^https?://|^//~', $font)) {
+                    $font = Tools::getShopDomainSsl(true) . _THEME_DIR_ . ltrim($font, '/');
+                }
+                $out .= '<link rel="preload" as="font" type="' . $type . '" href="' . Tools::safeOutput($font) . '" crossorigin>' . "\n";
+            }
+        }
+
+        return $out;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add Asset preloading settings with font checkboxes on Performance page
- inject generated preload links for CSS, JS and selected fonts in FrontController

## Testing
- `php -l controllers/admin/AdminPerformanceController.php`
- `php -l classes/controller/FrontController.php`
- `./vendor/bin/codecept run Unit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a256cffee8832d99a03d59b0a82994