### PR TITLE
Ensure default group select shows associated groups

### DIFF
--- a/js/admin/customer_groups.js
+++ b/js/admin/customer_groups.js
@@ -1,0 +1,39 @@
+$(function() {
+    var $form = $('#customer_form');
+    if (!$form.length) {
+        return;
+    }
+    var $defaultGroup = $('#id_default_group');
+    $('.groupBox').on('change', function() {
+        var groups = [];
+        $('.groupBox:checked').each(function() {
+            groups.push($(this).val());
+        });
+        $.ajax({
+            type: 'POST',
+            url: $form.attr('action') + '&ajax=1&action=updateCustomerGroups',
+            dataType: 'json',
+            data: {
+                id_customer: $form.find('input[name="id_customer"]').val(),
+                groupBox: groups,
+                token: $form.find('input[name="token"]').val()
+            },
+            success: function(response) {
+                if (!response) {
+                    return;
+                }
+                var current = $defaultGroup.val();
+                $defaultGroup.empty();
+                $.each(response, function(i, group) {
+                    $defaultGroup.append($('<option>', {
+                        value: group.id_group,
+                        text: group.name
+                    }));
+                });
+                if ($defaultGroup.find('option[value="' + current + '"]').length) {
+                    $defaultGroup.val(current);
+                }
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- filter default group options to only customer's groups
- update groups via Ajax when changing group access
- load helper script for dynamic group list updates

## Testing
- `php -l controllers/admin/AdminCustomersController.php`
- `node --check js/admin/customer_groups.js && echo 'JS OK'`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a63f1dddc4832d9557d1f9af8092a0