### PR TITLE
Fix default group list for customers

### DIFF
--- a/js/admin/customers.js
+++ b/js/admin/customers.js
@@ -1,0 +1,65 @@
+/**
+ * 2007-2016 PrestaShop
+ *
+ * thirty bees is an extension to the PrestaShop e-commerce software developed by PrestaShop SA
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.thirtybees.com for more information.
+ *
+ * @author    thirty bees <contact@thirtybees.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2017-2024 thirty bees
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * PrestaShop is an internationally registered trademark & property of PrestaShop SA
+ */
+
+/* global $, window */
+
+$(function () {
+  $('input.groupBox').on('change', function () {
+    var idCustomer = $('input[name="id_customer"]').val();
+    if (!idCustomer) {
+      return;
+    }
+    var groups = $('input.groupBox:checked').map(function () {
+      return $(this).val();
+    }).get();
+
+    $.ajax({
+      type: 'POST',
+      url: 'index.php?controller=AdminCustomers&token=' + window.token + '&ajax=1&action=updateGroupAccess&id_customer=' + idCustomer,
+      data: {groups: groups},
+      dataType: 'json'
+    }).done(function (resp) {
+      if (!resp || !resp.groups) {
+        return;
+      }
+      var $select = $('select[name="id_default_group"]');
+      var current = $select.val();
+      $select.empty();
+      $.each(resp.groups, function (i, group) {
+        $('<option>').val(group.id_group).text(group.name).appendTo($select);
+      });
+      if ($.inArray(current, groups) !== -1) {
+        $select.val(current);
+      } else if (resp.groups.length) {
+        $select.val(resp.groups[0].id_group);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- limit "Default customer group" options to groups actually assigned to the customer
- save group changes via AJAX and refresh the default-group dropdown immediately
- load new admin/customers.js to handle group access interactions

## Testing
- `php -l controllers/admin/AdminCustomersController.php`
- `./vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a63f1dddc4832d9557d1f9af8092a0