### PR TITLE
Fix default customer group selection via AJAX

### DIFF
--- a/js/admin/customers.js
+++ b/js/admin/customers.js
@@ -1,0 +1,36 @@
+$(function() {
+  var idCustomer = parseInt($('input[name="id_customer"]').val(), 10);
+  if (isNaN(idCustomer)) {
+    idCustomer = 0;
+  }
+  var $defaultGroup = $('select[name="id_default_group"]');
+  $('input[name^="groupBox"]').on('change', function() {
+    if (!idCustomer) {
+      return;
+    }
+    var groupIds = [];
+    $('input[name^="groupBox"]:checked').each(function() {
+      groupIds.push($(this).val());
+    });
+    $.ajax({
+      type: 'POST',
+      url: updateCustomerGroupsUrl,
+      dataType: 'json',
+      data: {
+        id_customer: idCustomer,
+        groupBox: groupIds
+      },
+      success: function(resp) {
+        if (resp && resp.groups) {
+          $defaultGroup.empty();
+          $.each(resp.groups, function(i, group) {
+            $('<option>', {
+              value: group.id_group,
+              text: group.name
+            }).appendTo($defaultGroup);
+          });
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- filter default group dropdown to only include currently associated groups
- add AJAX endpoint and script to refresh default group after toggling group access

## Testing
- `php -l controllers/admin/AdminCustomersController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a63f1dddc4832d9557d1f9af8092a0