### PR TITLE
feat: allow per-employee product tab ordering

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -138,6 +138,11 @@ class EmployeeCore extends ObjectModel implements InitializationCallback
     public $bo_show_screencast = false;
 
     /**
+     * @var string Ordered list of product tabs for this employee
+     */
+    public $bo_product_tabs;
+
+    /**
      * @var bool Status
      */
     public $active = 1;
@@ -197,6 +202,7 @@ class EmployeeCore extends ObjectModel implements InitializationCallback
             'bo_css'                   => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'size' => 64 ],
             'default_tab'              => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'dbDefault' => '0'],
             'bo_width'                 => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'dbDefault' => '0'],
+            'bo_product_tabs'          => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'dbType' => 'text', 'dbNullable' => true],
             'bo_menu'                  => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbType' => 'tinyint(1)', 'dbDefault' => '1'],
             'active'                   => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbDefault' => '0'],
             'optin'                    => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbDefault' => '1'],

--- a/controllers/admin/AdminEmployeesController.php
+++ b/controllers/admin/AdminEmployeesController.php
@@ -411,6 +411,13 @@ class AdminEmployeesControllerCore extends AdminController
                     'options' => $this->tabs_list,
                 ],
                 [
+                    'type'    => 'product_tabs',
+                    'label'   => $this->l('Product tabs order'),
+                    'name'    => 'bo_product_tabs',
+                    'values'  => AdminProductsController::getProductTabs(),
+                    'hint'    => $this->l('Drag and drop to reorder tabs on the product edit page.'),
+                ],
+                [
                     'type'    => 'select',
                     'label'   => $this->l('Language'),
                     'name'    => 'id_lang',
@@ -519,6 +526,7 @@ class AdminEmployeesControllerCore extends AdminController
 
         $this->fields_value['passwd'] = false;
         $this->fields_value['bo_theme_css'] = $obj->bo_theme.'|'.$obj->bo_css;
+        $this->fields_value['bo_product_tabs'] = $obj->bo_product_tabs;
 
         if (empty($obj->id)) {
             $this->fields_value['id_lang'] = $this->context->language->id;

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -101,6 +101,32 @@ class AdminProductsControllerCore extends AdminController
     protected $product_exists_in_shop = false;
 
     /**
+     * Returns list of available product tabs with translated names
+     *
+     * @return array
+     */
+    public static function getProductTabs()
+    {
+        return [
+            'Informations'   => Translate::getAdminTranslation('Information', 'AdminProducts'),
+            'Pack'           => Translate::getAdminTranslation('Pack', 'AdminProducts'),
+            'VirtualProduct' => Translate::getAdminTranslation('Virtual Product', 'AdminProducts'),
+            'Prices'         => Translate::getAdminTranslation('Prices', 'AdminProducts'),
+            'Seo'            => Translate::getAdminTranslation('SEO', 'AdminProducts'),
+            'Associations'   => Translate::getAdminTranslation('Associations', 'AdminProducts'),
+            'Images'         => Translate::getAdminTranslation('Images', 'AdminProducts'),
+            'Shipping'       => Translate::getAdminTranslation('Shipping', 'AdminProducts'),
+            'Combinations'   => Translate::getAdminTranslation('Combinations', 'AdminProducts'),
+            'Features'       => Translate::getAdminTranslation('Features', 'AdminProducts'),
+            'Customization'  => Translate::getAdminTranslation('Customization', 'AdminProducts'),
+            'Attachments'    => Translate::getAdminTranslation('Attachments', 'AdminProducts'),
+            'Quantities'     => Translate::getAdminTranslation('Quantities', 'AdminProducts'),
+            'Suppliers'      => Translate::getAdminTranslation('Suppliers', 'AdminProducts'),
+            'Warehouses'     => Translate::getAdminTranslation('Warehouses', 'AdminProducts'),
+        ];
+    }
+
+    /**
      * AdminProductsControllerCore constructor.
      *
      * @throws PrestaShopException
@@ -144,23 +170,7 @@ class AdminProductsControllerCore extends AdminController
         $this->allow_export = true;
 
         // @since 1.5 : translations for tabs
-        $this->available_tabs_lang = [
-            'Informations'   => $this->l('Information'),
-            'Pack'           => $this->l('Pack'),
-            'VirtualProduct' => $this->l('Virtual Product'),
-            'Prices'         => $this->l('Prices'),
-            'Seo'            => $this->l('SEO'),
-            'Images'         => $this->l('Images'),
-            'Associations'   => $this->l('Associations'),
-            'Shipping'       => $this->l('Shipping'),
-            'Combinations'   => $this->l('Combinations'),
-            'Features'       => $this->l('Features'),
-            'Customization'  => $this->l('Customization'),
-            'Attachments'    => $this->l('Attachments'),
-            'Quantities'     => $this->l('Quantities'),
-            'Suppliers'      => $this->l('Suppliers'),
-            'Warehouses'     => $this->l('Warehouses'),
-        ];
+        $this->available_tabs_lang = static::getProductTabs();
 
         $this->available_tabs = ['Quantities' => 6, 'Warehouses' => 14];
         if ($this->context->shop->getContext() != Shop::CONTEXT_GROUP) {
@@ -194,6 +204,19 @@ class AdminProductsControllerCore extends AdminController
                 $this->available_tabs['Module'.ucfirst($m['module'])] = 23;
                 $this->available_tabs_lang['Module'.ucfirst($m['module'])] = Module::getModuleName($m['module']);
             }
+        }
+
+        // Reorder tabs based on employee preference
+        if ($this->context->employee && $this->context->employee->bo_product_tabs) {
+            $order = array_filter(explode(',', $this->context->employee->bo_product_tabs));
+            $reordered = [];
+            foreach ($order as $tab) {
+                if (isset($this->available_tabs[$tab])) {
+                    $reordered[$tab] = $this->available_tabs[$tab];
+                    unset($this->available_tabs[$tab]);
+                }
+            }
+            $this->available_tabs = $reordered + $this->available_tabs;
         }
 
         if (Tools::getValue('reset_filter_category')) {


### PR DESCRIPTION
## Summary
- store employee-specific product tab order
- allow employees to reorder product edit tabs in profile
- apply employee tab order when editing products

## Testing
- `php -l classes/Employee.php controllers/admin/AdminEmployeesController.php controllers/admin/AdminProductsController.php`

------
https://chatgpt.com/codex/tasks/task_e_68a662a8ff94832daaaeda75771ac32a