### PR TITLE
Allow employees to sort product tabs in profile

### DIFF
--- a/admin-dev/themes/default/template/controllers/employees/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/employees/helpers/form/form.tpl
@@ -25,28 +25,35 @@
 {extends file="helpers/form/form.tpl"}
 
 {block name="input"}
-	{if $input.type == 'default_tab'}
-	<select id="{$input.name}" name="{$input.name}" class="chosen fixed-width-xxl">
-		{foreach $input.options AS $option}
-			{if isset($option.children) && $option.children|@count}
-				<optgroup label="{$option.name|escape:'html':'UTF-8'}"></optgroup>
-				{foreach $option.children AS $children}
-					<option value="{$children.id_tab}" {if $fields_value[$input.name] == $children.id_tab}selected="selected"{/if}>{$children.name|escape:'html':'UTF-8'}</option>
-				{/foreach}
-			{else}
-				<option value="{$option.id_tab}" {if $fields_value[$input.name] == $option.id_tab}selected="selected"{/if}>{$option.name|escape:'html':'UTF-8'}</option>
-			{/if}
-		{/foreach}
-	</select>
-	{else}
-		{$smarty.block.parent}
-	{/if}
+        {if $input.type == 'default_tab'}
+        <select id="{$input.name}" name="{$input.name}" class="chosen fixed-width-xxl">
+                {foreach $input.options AS $option}
+                        {if isset($option.children) && $option.children|@count}
+                                <optgroup label="{$option.name|escape:'html':'UTF-8'}"></optgroup>
+                                {foreach $option.children AS $children}
+                                        <option value="{$children.id_tab}" {if $fields_value[$input.name] == $children.id_tab}selected="selected"{/if}>{$children.name|escape:'html':'UTF-8'}</option>
+                                {/foreach}
+                        {else}
+                                <option value="{$option.id_tab}" {if $fields_value[$input.name] == $option.id_tab}selected="selected"{/if}>{$option.name|escape:'html':'UTF-8'}</option>
+                        {/if}
+                {/foreach}
+        </select>
+        {elseif $input.type == 'product_tabs'}
+        <input type="hidden" name="{$input.name}" id="{$input.name}" value="{$fields_value[$input.name]|escape:'html':'UTF-8'}" />
+        <ul id="product_tabs_sort" class="list-group">
+                {foreach from=$input.values key=tab item=name}
+                        <li class="list-group-item" data-tab="{$tab}">{$name}</li>
+                {/foreach}
+        </ul>
+        {else}
+                {$smarty.block.parent}
+        {/if}
 {/block}
 
 {block name=script}
 	$(document).ready(function(){
-		$('select[name=id_profile]').change(function(){
-			ifSuperAdmin($(this));
+                $('select[name=id_profile]').change(function(){
+                        ifSuperAdmin($(this));
 
 			$.ajax({
 				url: "{$link->getAdminLink('AdminEmployees')|addslashes}",
@@ -75,8 +82,15 @@
 				}
 			});
 		});
-		ifSuperAdmin($('select[name=id_profile]'));
-	});
+                ifSuperAdmin($('select[name=id_profile]'));
+
+                $('#product_tabs_sort').sortable({
+                        update: function() {
+                                var order = $('#product_tabs_sort').children().map(function(){return $(this).data('tab');}).get();
+                                $('#bo_product_tabs').val(order.join(','));
+                        }
+                });
+        });
 
 	function ifSuperAdmin(el)
 	{

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -138,6 +138,11 @@ class EmployeeCore extends ObjectModel implements InitializationCallback
     public $bo_show_screencast = false;
 
     /**
+     * @var string|null Ordered product tabs
+     */
+    public $bo_product_tabs;
+
+    /**
      * @var bool Status
      */
     public $active = 1;
@@ -198,6 +203,7 @@ class EmployeeCore extends ObjectModel implements InitializationCallback
             'default_tab'              => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'dbDefault' => '0'],
             'bo_width'                 => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'dbDefault' => '0'],
             'bo_menu'                  => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbType' => 'tinyint(1)', 'dbDefault' => '1'],
+            'bo_product_tabs'          => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'dbType' => 'text', 'dbNullable' => true],
             'active'                   => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbDefault' => '0'],
             'optin'                    => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbDefault' => '1'],
             'last_connection_date'     => ['type' => self::TYPE_DATE, 'validate' => 'isDate', 'dbNullable' => true],

--- a/controllers/admin/AdminEmployeesController.php
+++ b/controllers/admin/AdminEmployeesController.php
@@ -250,6 +250,7 @@ class AdminEmployeesControllerCore extends AdminController
         $this->addJS(__PS_BASE_URI__.$this->admin_webpath.'/themes/'.$this->bo_theme.'/js/vendor/jquery-passy.js');
         $this->addjQueryPlugin('validate');
         $this->addJS(_PS_JS_DIR_.'jquery/plugins/validate/localization/messages_'.$this->context->language->iso_code.'.js');
+        $this->addJqueryUI('ui.sortable');
     }
 
     /**
@@ -372,6 +373,33 @@ class AdminEmployeesControllerCore extends AdminController
         $image = _PS_EMPLOYEE_IMG_DIR_.$obj->id.'.'.$this->imageType;
         $imageUrl = ImageManager::thumbnail($image, $this->table.'_'.(int) $obj->id.'.'.$this->imageType, 150, $this->imageType, true, true);
 
+        $productTabs = [
+            'Informations'   => $this->l('Information'),
+            'Pack'           => $this->l('Pack'),
+            'VirtualProduct' => $this->l('Virtual Product'),
+            'Prices'         => $this->l('Prices'),
+            'Seo'            => $this->l('SEO'),
+            'Images'         => $this->l('Images'),
+            'Associations'   => $this->l('Associations'),
+            'Shipping'       => $this->l('Shipping'),
+            'Combinations'   => $this->l('Combinations'),
+            'Features'       => $this->l('Features'),
+            'Customization'  => $this->l('Customization'),
+            'Attachments'    => $this->l('Attachments'),
+            'Quantities'     => $this->l('Quantities'),
+            'Suppliers'      => $this->l('Suppliers'),
+            'Warehouses'     => $this->l('Warehouses'),
+        ];
+
+        $order = $obj->bo_product_tabs ? array_map('trim', explode(',', $obj->bo_product_tabs)) : array_keys($productTabs);
+        $orderedTabs = [];
+        foreach ($order as $tab) {
+            if (isset($productTabs[$tab])) {
+                $orderedTabs[$tab] = $productTabs[$tab];
+                unset($productTabs[$tab]);
+            }
+        }
+        $productTabs = $orderedTabs + $productTabs;
 
         $this->fields_form['input'] = array_merge(
             $this->fields_form['input'], [
@@ -432,6 +460,13 @@ class AdminEmployeesControllerCore extends AdminController
                     ],
                     'onchange' => 'var value_array = $(this).val().split("|"); $("link").first().attr("href", "themes/" + value_array[0] + "/css/" + value_array[1]);',
                     'hint'     => $this->l('Back office theme.'),
+                ],
+                [
+                    'type'  => 'product_tabs',
+                    'label' => $this->l('Product tabs order'),
+                    'name'  => 'bo_product_tabs',
+                    'values'=> $productTabs,
+                    'hint'  => $this->l('Drag and drop to reorder product tabs.'),
                 ],
                 [
                     'type'     => 'radio',
@@ -519,6 +554,7 @@ class AdminEmployeesControllerCore extends AdminController
 
         $this->fields_value['passwd'] = false;
         $this->fields_value['bo_theme_css'] = $obj->bo_theme.'|'.$obj->bo_css;
+        $this->fields_value['bo_product_tabs'] = implode(',', array_keys($productTabs));
 
         if (empty($obj->id)) {
             $this->fields_value['id_lang'] = $this->context->language->id;

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -196,6 +196,8 @@ class AdminProductsControllerCore extends AdminController
             }
         }
 
+        $this->applyEmployeeTabOrder();
+
         if (Tools::getValue('reset_filter_category')) {
             $this->context->cookie->id_category_products_filter = false;
         }
@@ -379,6 +381,26 @@ class AdminProductsControllerCore extends AdminController
                 'position'   => 'position',
             ];
         }
+    }
+
+    /**
+     * Apply product tab order defined by employee
+     */
+    protected function applyEmployeeTabOrder()
+    {
+        $order = $this->context->employee->bo_product_tabs;
+        if (!$order) {
+            return;
+        }
+        $tabs = array_map('trim', explode(',', $order));
+        $ordered = [];
+        foreach ($tabs as $tab) {
+            if (array_key_exists($tab, $this->available_tabs)) {
+                $ordered[$tab] = $this->available_tabs[$tab];
+                unset($this->available_tabs[$tab]);
+            }
+        }
+        $this->available_tabs = $ordered + $this->available_tabs;
     }
 
     /**

--- a/tests/golden_files/db_schema.sql
+++ b/tests/golden_files/db_schema.sql
@@ -863,6 +863,7 @@ CREATE TABLE `PREFIX_employee` (
   `default_tab` int(11) unsigned NOT NULL DEFAULT '0',
   `bo_width` int(11) unsigned NOT NULL DEFAULT '0',
   `bo_menu` tinyint(1) NOT NULL DEFAULT '1',
+  `bo_product_tabs` text DEFAULT NULL,
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `optin` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `last_connection_date` datetime DEFAULT NULL,


### PR DESCRIPTION
## Summary
- store per-employee product tab ordering via new `bo_product_tabs` field
- add sortable product tab list in employee profile settings
- apply employee-defined product tab order in product editor

## Testing
- `php -l classes/Employee.php`
- `php -l controllers/admin/AdminEmployeesController.php`
- `php -l controllers/admin/AdminProductsController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a662a8ff94832daaaeda75771ac32a