### PR TITLE
Allow employees to customize product tab order

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -133,6 +133,11 @@ class EmployeeCore extends ObjectModel implements InitializationCallback
     public $bo_menu = 1;
 
     /**
+     * @var string JSON encoded product tab order
+     */
+    public $product_tabs;
+
+    /**
      * @var bool
      */
     public $bo_show_screencast = false;
@@ -198,6 +203,7 @@ class EmployeeCore extends ObjectModel implements InitializationCallback
             'default_tab'              => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'dbDefault' => '0'],
             'bo_width'                 => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'dbDefault' => '0'],
             'bo_menu'                  => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbType' => 'tinyint(1)', 'dbDefault' => '1'],
+            'product_tabs'             => ['type' => self::TYPE_STRING, 'validate' => 'isAnything', 'dbType' => 'text', 'dbNullable' => true],
             'active'                   => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbDefault' => '0'],
             'optin'                    => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbDefault' => '1'],
             'last_connection_date'     => ['type' => self::TYPE_DATE, 'validate' => 'isDate', 'dbNullable' => true],

--- a/controllers/admin/AdminEmployeesController.php
+++ b/controllers/admin/AdminEmployeesController.php
@@ -45,6 +45,9 @@ class AdminEmployeesControllerCore extends AdminController
     /** @var array tabs list */
     protected $tabs_list = [];
 
+    /** @var array product tabs list */
+    protected $product_tabs = [];
+
     /** @var bool $restrict_edition */
     protected $restrict_edition = false;
 
@@ -207,6 +210,24 @@ class AdminEmployeesControllerCore extends AdminController
                 }
             }
         }
+
+        $this->product_tabs = [
+            ['id' => 'Informations', 'name' => $this->l('Information')],
+            ['id' => 'Pack', 'name' => $this->l('Pack')],
+            ['id' => 'VirtualProduct', 'name' => $this->l('Virtual Product')],
+            ['id' => 'Prices', 'name' => $this->l('Prices')],
+            ['id' => 'Seo', 'name' => $this->l('SEO')],
+            ['id' => 'Images', 'name' => $this->l('Images')],
+            ['id' => 'Associations', 'name' => $this->l('Associations')],
+            ['id' => 'Shipping', 'name' => $this->l('Shipping')],
+            ['id' => 'Combinations', 'name' => $this->l('Combinations')],
+            ['id' => 'Features', 'name' => $this->l('Features')],
+            ['id' => 'Customization', 'name' => $this->l('Customization')],
+            ['id' => 'Attachments', 'name' => $this->l('Attachments')],
+            ['id' => 'Quantities', 'name' => $this->l('Quantities')],
+            ['id' => 'Suppliers', 'name' => $this->l('Suppliers')],
+            ['id' => 'Warehouses', 'name' => $this->l('Warehouses')],
+        ];
 
         $homeTab = Tab::getInstanceFromClassName('AdminDashboard', $this->context->language->id);
         $this->tabs_list[$homeTab->id] = [
@@ -434,6 +455,17 @@ class AdminEmployeesControllerCore extends AdminController
                     'hint'     => $this->l('Back office theme.'),
                 ],
                 [
+                    'type'    => 'swap',
+                    'label'   => $this->l('Product tabs'),
+                    'name'    => 'product_tabs',
+                    'options' => [
+                        'query' => $this->product_tabs,
+                        'id'    => 'id',
+                        'name'  => 'name',
+                    ],
+                    'hint'    => $this->l('Select and order tabs for product editing.'),
+                ],
+                [
                     'type'     => 'radio',
                     'label'    => $this->l('Admin menu orientation'),
                     'name'     => 'bo_menu',
@@ -519,6 +551,14 @@ class AdminEmployeesControllerCore extends AdminController
 
         $this->fields_value['passwd'] = false;
         $this->fields_value['bo_theme_css'] = $obj->bo_theme.'|'.$obj->bo_css;
+
+        $tabsOrder = $obj->product_tabs ? json_decode($obj->product_tabs, true) : [];
+        if (is_array($tabsOrder) && $tabsOrder) {
+            asort($tabsOrder, SORT_NUMERIC);
+            $this->fields_value['product_tabs'] = array_keys($tabsOrder);
+        } else {
+            $this->fields_value['product_tabs'] = array_column($this->product_tabs, 'id');
+        }
 
         if (empty($obj->id)) {
             $this->fields_value['id_lang'] = $this->context->language->id;
@@ -743,6 +783,16 @@ class AdminEmployeesControllerCore extends AdminController
      */
     public function postProcess()
     {
+        $tabs = Tools::getValue('product_tabs_selected');
+        if (is_array($tabs)) {
+            $order = [];
+            $i = 0;
+            foreach ($tabs as $tab) {
+                $order[$tab] = $i++;
+            }
+            $_POST['product_tabs'] = json_encode($order);
+        }
+
         if ((Tools::isSubmit('submitBulkdeleteemployee') || Tools::isSubmit('submitBulkdisableSelectionemployee') || Tools::isSubmit('deleteemployee') || Tools::isSubmit('status') || Tools::isSubmit('statusemployee') || Tools::isSubmit('submitAddemployee')) && _PS_MODE_DEMO_) {
             $this->errors[] = Tools::displayError('This functionality has been disabled.');
 

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -184,9 +184,6 @@ class AdminProductsControllerCore extends AdminController
             );
         }
 
-        // Sort the tabs that need to be preloaded by their priority number
-        asort($this->available_tabs, SORT_NUMERIC);
-
         /* Adding tab if modules are hooked */
         $modulesList = Hook::getHookModuleExecList('displayAdminProductsExtra');
         if (is_array($modulesList) && count($modulesList) > 0) {
@@ -195,6 +192,19 @@ class AdminProductsControllerCore extends AdminController
                 $this->available_tabs_lang['Module'.ucfirst($m['module'])] = Module::getModuleName($m['module']);
             }
         }
+
+        // Apply employee specific tab order
+        $employeeTabOrder = json_decode((string)$this->context->employee->product_tabs, true);
+        if (is_array($employeeTabOrder)) {
+            foreach ($employeeTabOrder as $tab => $position) {
+                if (isset($this->available_tabs[$tab])) {
+                    $this->available_tabs[$tab] = (int)$position;
+                }
+            }
+        }
+
+        // Sort the tabs that need to be preloaded by their priority number
+        asort($this->available_tabs, SORT_NUMERIC);
 
         if (Tools::getValue('reset_filter_category')) {
             $this->context->cookie->id_category_products_filter = false;


### PR DESCRIPTION
## Summary
- allow employees to configure product edit tab order in their profile
- store per-employee tab ordering
- apply employee-specific tab order in product editor

## Testing
- `php -l classes/Employee.php`
- `php -l controllers/admin/AdminProductsController.php`
- `php -l controllers/admin/AdminEmployeesController.php`
- `vendor/bin/codecept run Unit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a662a8ff94832daaaeda75771ac32a