### PR TITLE
Allow per-employee product tab sorting

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -230,12 +230,34 @@
 														{/if}
 													{/foreach}
 													</select>
-													<a href="#" id="removeSwap" class="btn btn-default btn-block"><i class="icon-arrow-left"></i> {l s='Remove'}</a>
-												</div>
-											</div>
-										</div>
-									</div>
-								{elseif $input.type == 'select'}
+                                                                                                       <a href="#" id="removeSwap" class="btn btn-default btn-block"><i class="icon-arrow-left"></i> {l s='Remove'}</a>
+                                                                                               </div>
+                                                                                       </div>
+                                                                               </div>
+                                                                       </div>
+                                                               {elseif $input.type == 'product_tabs'}
+                                                                       <div class="form-group">
+                                                                               <div class="col-lg-9">
+                                                                                       <input type="hidden" name="{$input.name}" id="{$input.name}" value="{$fields_value[$input.name]|escape:'html':'UTF-8'}" />
+                                                                                       <ul id="{$input.name}_sortable" class="list-unstyled">
+                                                                                       {foreach $input.order as $tab}
+                                                                                               <li class="ui-state-default" data-tab="{$tab|escape:'html':'UTF-8'}">{$input.tabs[$tab]|escape:'html':'UTF-8'}</li>
+                                                                                       {/foreach}
+                                                                                       </ul>
+                                                                               </div>
+                                                                       </div>
+                                                                       <script type="text/javascript">
+                                                                       $(function(){
+                                                                               var $s = $('#{$input.name}_sortable');
+                                                                               $s.sortable({
+                                                                                       update: function(){
+                                                                                               var order = $s.find('li').map(function(){return $(this).data('tab');}).get();
+                                                                                               $('#{$input.name}').val(order.join(','));
+                                                                                       }
+                                                                               });
+                                                                       });
+                                                                       </script>
+                                                                {elseif $input.type == 'select'}
 									{if isset($input.options.query) && !$input.options.query && isset($input.empty_message)}
 										{$input.empty_message}
 										{$input.required = false}

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -138,6 +138,11 @@ class EmployeeCore extends ObjectModel implements InitializationCallback
     public $bo_show_screencast = false;
 
     /**
+     * @var string Product tabs order
+     */
+    public $product_tabs;
+
+    /**
      * @var bool Status
      */
     public $active = 1;
@@ -198,6 +203,7 @@ class EmployeeCore extends ObjectModel implements InitializationCallback
             'default_tab'              => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'dbDefault' => '0'],
             'bo_width'                 => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'dbDefault' => '0'],
             'bo_menu'                  => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbType' => 'tinyint(1)', 'dbDefault' => '1'],
+            'product_tabs'             => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'dbType' => 'text', 'dbNullable' => true],
             'active'                   => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbDefault' => '0'],
             'optin'                    => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbDefault' => '1'],
             'last_connection_date'     => ['type' => self::TYPE_DATE, 'validate' => 'isDate', 'dbNullable' => true],

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -196,6 +196,18 @@ class AdminProductsControllerCore extends AdminController
             }
         }
 
+        if (!empty($this->context->employee->product_tabs)) {
+            $order = array_map('trim', explode(',', $this->context->employee->product_tabs));
+            $sorted = [];
+            foreach ($order as $tab) {
+                if (isset($this->available_tabs[$tab])) {
+                    $sorted[$tab] = $this->available_tabs[$tab];
+                    unset($this->available_tabs[$tab]);
+                }
+            }
+            $this->available_tabs = $sorted + $this->available_tabs;
+        }
+
         if (Tools::getValue('reset_filter_category')) {
             $this->context->cookie->id_category_products_filter = false;
         }


### PR DESCRIPTION
## Summary
- store preferred product tab order on each employee
- let employees reorder product tabs in their profile
- honor the stored order when rendering product pages

## Testing
- `php -l classes/Employee.php controllers/admin/AdminEmployeesController.php controllers/admin/AdminProductsController.php`
- `./vendor/bin/codecept run Unit -c codeception.yml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a662a8ff94832daaaeda75771ac32a