### PR TITLE
feat: allow assigning images to attribute groups

### DIFF
--- a/admin-dev/themes/default/template/controllers/attribute_generator/content.tpl
+++ b/admin-dev/themes/default/template/controllers/attribute_generator/content.tpl
@@ -30,8 +30,10 @@
     var priceDisplayPrecision = 0;
   {/if}
   var priceDatabasePrecision = {$smarty.const._TB_PRICE_DATABASE_PRECISION_};
-	var attrs = new Array();
-	attrs[0] = new Array(0, '---');
+        var attrs = new Array();
+        attrs[0] = new Array(0, '---');
+        var groups_affecting_view = {$groups_affecting_view|@json_encode};
+        var imageOptionsHtml = '{$image_options_html|escape:'javascript'}';
 
 	{foreach $attribute_js as $idgrp => $group}
 		{assign var="row" value="attrs[{$idgrp}] = new Array(0, '---'"}
@@ -68,12 +70,23 @@
 
 {if $generate}<div class="alert alert-success clearfix">{l s='%d product(s) successfully created.' sprintf=$combinations_size}</div>{/if}
 <form enctype="multipart/form-data" method="post" id="generator" action="{$url_generator}">
-	<div class="panel">
-		<h3>
-			<i class="icon-asterisk"></i>
-			{l s='Attributes generator'}
-		</h3>
-		<div class="row">
+        <div class="panel">
+                <h3>
+                        <i class="icon-asterisk"></i>
+                        {l s='Attributes generator'}
+                </h3>
+
+                {if $preuploaded_images|@count}
+                        <div class="well">
+                                {foreach $preuploaded_images as $img}
+                                        <img src="{$img}" class="img-thumbnail" alt="" />
+                                {/foreach}
+                        </div>
+                {else}
+                        <div class="alert alert-warning">{l s='Currently no images are uploaded'}</div>
+                {/if}
+
+                <div class="row">
 			<div class="col-lg-3">
 				<div class="form-group">
 					<select multiple name="attributes[]" id="attribute_group" style="height: 65vh">
@@ -93,12 +106,8 @@
 					<button type="button" class="btn btn-default pull-right" onclick="add_attr_multiple();"><i class="icon-plus-sign"></i> {l s='Add'}</button>
 				</div>
 			</div>
-			<div class="col-lg-8 col-lg-offset-1">
-				<div class="alert alert-info">{l s='The Combinations Generator is a tool that allows you to easily create a series of combinations by selecting the related attributes. For example, if you\'re selling t-shirts in three different sizes and two different colors, the generator will create six combinations for you.'}</div>
-
-				<div class="alert alert-info">{l s='You\'re currently generating combinations for the following product:'} <b>{$product_name|escape:'html':'UTF-8'}</b></div>
-
-				<div class="alert alert-info"><strong>{l s='Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")'}</strong></div>
+                        <div class="col-lg-9">
+                                <div class="alert alert-info"><strong>{l s='Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")'}</strong></div>
 
 				{foreach $attribute_groups as $k => $attribute_group}
 					{if isset($attribute_js[$attribute_group['id_attribute_group']])}
@@ -124,9 +133,12 @@
 									<th>
 										<span class="title_box">{l s='Length [%s]' sprintf=[$dimension_unit]}</span>
 									</th>
-									<th>
-										<span class="title_box">{l s='Depth [%s]' sprintf=[$dimension_unit]}</span>
-									</th>
+                                                                        <th>
+                                                                                <span class="title_box">{l s='Depth [%s]' sprintf=[$dimension_unit]}</span>
+                                                                        </th>
+                                                                        <th>
+                                                                                <span class="title_box">{l s='Image'}</span>
+                                                                        </th>
 								</tr>
 							</thead>
 							<tbody id="table_{$attribute_group['id_attribute_group']}" name="result_table">

--- a/classes/AttributeGroup.php
+++ b/classes/AttributeGroup.php
@@ -45,6 +45,7 @@ class AttributeGroupCore extends ObjectModel
             'is_color_group' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbType' => 'tinyint(1)', 'dbDefault' => '0'],
             'group_type'     => ['type' => self::TYPE_STRING, 'required' => true, 'values' => ['select', 'radio', 'color'], 'dbDefault' => 'select'],
             'position'       => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'dbDefault' => '0'],
+            'affect_product_view' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbType' => 'tinyint(1)', 'dbDefault' => '0'],
 
             /* Lang fields */
             'name'           => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 128],
@@ -64,6 +65,8 @@ class AttributeGroupCore extends ObjectModel
     public $position;
     /** @var string $group_type */
     public $group_type;
+    /** @var bool $affect_product_view */
+    public $affect_product_view;
     /** @var string|string[] Public Name */
     public $public_name;
     /**

--- a/controllers/admin/AdminAttributeGeneratorController.php
+++ b/controllers/admin/AdminAttributeGeneratorController.php
@@ -266,6 +266,28 @@ class AdminAttributeGeneratorControllerCore extends AdminController
         $attributeGroups = AttributeGroup::getAttributesGroups($this->context->language->id);
         $this->product = new Product(Tools::getIntValue('id_product'));
 
+        $groupsAffecting = [];
+        foreach ($attributeGroups as $group) {
+            if (!empty($group['affect_product_view'])) {
+                $groupsAffecting[$group['id_attribute_group']] = true;
+            }
+        }
+
+        $preloadedImages = [];
+        $imgDir = _PS_IMG_DIR_.'attributes/';
+        if (is_dir($imgDir)) {
+            foreach (scandir($imgDir) as $file) {
+                if (preg_match('/\.(jpe?g|png|gif)$/i', $file)) {
+                    $preloadedImages[] = _PS_IMG_."attributes/".$file;
+                }
+            }
+        }
+
+        $optionsHtml = '<option value="">--</option>';
+        foreach ($preloadedImages as $img) {
+            $optionsHtml .= '<option value="'.$img.'">'.basename($img).'</option>';
+        }
+
         $this->context->smarty->assign(
             [
                 'tax_rates'                 => $this->product->getTaxesRate(),
@@ -276,6 +298,9 @@ class AdminAttributeGeneratorControllerCore extends AdminController
                 'url_generator'             => static::$currentIndex.'&id_product='.Tools::getIntValue('id_product').'&attributegenerator&token='.Tools::getValue('token'),
                 'attribute_groups'          => $attributeGroups,
                 'attribute_js'              => $attributeJs,
+                'groups_affecting_view'     => $groupsAffecting,
+                'preuploaded_images'        => $preloadedImages,
+                'image_options_html'        => $optionsHtml,
                 'toolbar_btn'               => $this->toolbar_btn,
                 'toolbar_scroll'            => true,
                 'show_page_header_toolbar'  => $this->show_page_header_toolbar,

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -337,6 +337,25 @@ class AdminAttributesGroupsControllerCore extends AdminController
                     'col'      => '2',
                     'hint'     => $this->l('The way the attribute\'s values will be presented to the customers in the product\'s page.'),
                 ],
+                [
+                    'type'  => 'switch',
+                    'label' => $this->l('Affecting product view'),
+                    'name'  => 'affect_product_view',
+                    'hint'  => $this->l('Determines if attributes in this group could use Combinations generator and uploaded images'),
+                    'desc'  => $this->l('Set YES to be able to use Combinations generator to assign preuploaded images to attributes in this group'),
+                    'values' => [
+                        [
+                            'id' => 'affect_product_view_on',
+                            'value' => 1,
+                            'label' => $this->l('Yes'),
+                        ],
+                        [
+                            'id' => 'affect_product_view_off',
+                            'value' => 0,
+                            'label' => $this->l('No'),
+                        ],
+                    ],
+                ],
             ],
         ];
 

--- a/js/admin/attributes.js
+++ b/js/admin/attributes.js
@@ -152,6 +152,11 @@ function create_attribute_row(id, idGroup, name, price, weight, width, height, d
   html += '<td><input type="text" value="' + width + '" name="width_impact_' + id + '"></td>';
   html += '<td><input type="text" value="' + height + '" name="height_impact_' + id + '"></td>';
   html += '<td><input type="text" value="' + depth + '" name="depth_impact_' + id + '"></td>';
+  if (typeof groups_affecting_view !== 'undefined' && groups_affecting_view[idGroup]) {
+    html += '<td><select name="image_' + id + '" class="attribute-image-select">' + imageOptionsHtml + '</select></td>';
+  } else {
+    html += '<td></td>';
+  }
   html += '</tr>';
 
   return html;


### PR DESCRIPTION
## Summary
- allow attribute groups to mark themselves as affecting product view
- show preuploaded attribute images in combinations generator
- expose image selection per attribute when group affects product view

## Testing
- `php -l classes/AttributeGroup.php controllers/admin/AdminAttributesGroupsController.php controllers/admin/AdminAttributeGeneratorController.php`
- `vendor/bin/codecept run Unit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a85cd19ffc832da566f86bffc9b42f