### PR TITLE
Enable attribute images in combination generator

### DIFF
--- a/admin-dev/themes/default/template/controllers/attribute_generator/content.tpl
+++ b/admin-dev/themes/default/template/controllers/attribute_generator/content.tpl
@@ -30,7 +30,8 @@
     var priceDisplayPrecision = 0;
   {/if}
   var priceDatabasePrecision = {$smarty.const._TB_PRICE_DATABASE_PRECISION_};
-	var attrs = new Array();
+  var product_images = {$product_images|json_encode};
+        var attrs = new Array();
 	attrs[0] = new Array(0, '---');
 
 	{foreach $attribute_js as $idgrp => $group}
@@ -79,7 +80,7 @@
 					<select multiple name="attributes[]" id="attribute_group" style="height: 65vh">
 						{foreach $attribute_groups as $k => $attribute_group}
 							{if isset($attribute_js[$attribute_group['id_attribute_group']])}
-								<optgroup name="{$attribute_group['id_attribute_group']}" id="{$attribute_group['id_attribute_group']}" label="{$attribute_group['name']|escape:'html':'UTF-8'}">
+                                                                <optgroup name="{$attribute_group['id_attribute_group']}" id="{$attribute_group['id_attribute_group']}" label="{$attribute_group['name']|escape:'html':'UTF-8'}" data-affects-product-view="{$attribute_group['affects_product_view']}">
 									{foreach $attribute_js[$attribute_group['id_attribute_group']] as $k => $v}
 										<option name="{$k}" id="attr_{$k}" value="{$v|escape:'html':'UTF-8'}" title="{$v|escape:'html':'UTF-8'}">{$v|escape:'html':'UTF-8'}</option>
 									{/foreach}
@@ -93,12 +94,20 @@
 					<button type="button" class="btn btn-default pull-right" onclick="add_attr_multiple();"><i class="icon-plus-sign"></i> {l s='Add'}</button>
 				</div>
 			</div>
-			<div class="col-lg-8 col-lg-offset-1">
-				<div class="alert alert-info">{l s='The Combinations Generator is a tool that allows you to easily create a series of combinations by selecting the related attributes. For example, if you\'re selling t-shirts in three different sizes and two different colors, the generator will create six combinations for you.'}</div>
+                        <div class="col-lg-9">
+                                <div class="alert alert-info"><strong>{l s='Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")'}</strong></div>
 
-				<div class="alert alert-info">{l s='You\'re currently generating combinations for the following product:'} <b>{$product_name|escape:'html':'UTF-8'}</b></div>
-
-				<div class="alert alert-info"><strong>{l s='Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")'}</strong></div>
+                                {if $product_images|@count}
+                                <div class="form-group">
+                                        <ul class="list-inline">
+                                                {foreach $product_images as $img}
+                                                        <li><img src="{$link->getImageLink($product_link_rewrite, $img.id_image, 'small_default')}" alt="{$img.legend|escape:'html':'UTF-8'}" /></li>
+                                                {/foreach}
+                                        </ul>
+                                </div>
+                                {else}
+                                <div class="alert alert-info">{l s='Currently no images are uploaded'}</div>
+                                {/if}
 
 				{foreach $attribute_groups as $k => $attribute_group}
 					{if isset($attribute_js[$attribute_group['id_attribute_group']])}
@@ -124,9 +133,14 @@
 									<th>
 										<span class="title_box">{l s='Length [%s]' sprintf=[$dimension_unit]}</span>
 									</th>
-									<th>
-										<span class="title_box">{l s='Depth [%s]' sprintf=[$dimension_unit]}</span>
-									</th>
+                                                                        <th>
+                                                                                <span class="title_box">{l s='Depth [%s]' sprintf=[$dimension_unit]}</span>
+                                                                        </th>
+                                                                        {if $attribute_group['affects_product_view']}
+                                                                        <th>
+                                                                                <span class="title_box">{l s='Image'}</span>
+                                                                        </th>
+                                                                        {/if}
 								</tr>
 							</thead>
 							<tbody id="table_{$attribute_group['id_attribute_group']}" name="result_table">
@@ -145,9 +159,10 @@
 												{$attribute['weight']},
 												{$attribute['width']},
 												{$attribute['height']},
-												{$attribute['depth']}
-											)
-									);
+                                                                                                {$attribute['depth']},
+                                                                                                {$attribute_group['affects_product_view']}
+                                                                                        )
+                                                                        );
 									toggle(getE('table_' + {$attribute_group['id_attribute_group']}).parentNode, true);
 								</script>
 							{/foreach}

--- a/classes/AttributeGroup.php
+++ b/classes/AttributeGroup.php
@@ -43,6 +43,7 @@ class AttributeGroupCore extends ObjectModel
         'multilang' => true,
         'fields'    => [
             'is_color_group' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbType' => 'tinyint(1)', 'dbDefault' => '0'],
+            'affects_product_view' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'dbType' => 'tinyint(1)', 'dbDefault' => '0'],
             'group_type'     => ['type' => self::TYPE_STRING, 'required' => true, 'values' => ['select', 'radio', 'color'], 'dbDefault' => 'select'],
             'position'       => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'dbDefault' => '0'],
 
@@ -60,6 +61,8 @@ class AttributeGroupCore extends ObjectModel
     public $name;
     /** @var bool $is_color_group */
     public $is_color_group;
+    /** @var bool $affects_product_view */
+    public $affects_product_view;
     /** @var int $position */
     public $position;
     /** @var string $group_type */

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -337,6 +337,27 @@ class AdminAttributesGroupsControllerCore extends AdminController
                     'col'      => '2',
                     'hint'     => $this->l('The way the attribute\'s values will be presented to the customers in the product\'s page.'),
                 ],
+                [
+                    'type' => 'switch',
+                    'label' => $this->l('Affecting product view'),
+                    'name' => 'affects_product_view',
+                    'is_bool' => true,
+                    'hint' => $this->l('Determines if attributes in this group could use Combinations generator and uploaded images'),
+                    'desc' => $this->l('Set YES to be able to use Combinations generator to assign preuploaded images to attributes in this group'),
+                    'values' => [
+                        [
+                            'id' => 'affects_product_view_on',
+                            'value' => 1,
+                            'label' => $this->l('Yes'),
+                        ],
+                        [
+                            'id' => 'affects_product_view_off',
+                            'value' => 0,
+                            'label' => $this->l('No'),
+                        ],
+                    ],
+                    'col' => '2',
+                ],
             ],
         ];
 

--- a/js/admin/attributes.js
+++ b/js/admin/attributes.js
@@ -142,7 +142,7 @@ function del_attr_multiple() {
   }
 }
 
-function create_attribute_row(id, idGroup, name, price, weight, width, height, depth) {
+function create_attribute_row(id, idGroup, name, price, weight, width, height, depth, affectsView) {
   var html = '';
   html += '<tr id="result_' + id + '">';
   html += '<td><input type="hidden" value="' + id + '" name="options[' + idGroup + '][' + id + ']" />' + name + '</td>';
@@ -152,6 +152,17 @@ function create_attribute_row(id, idGroup, name, price, weight, width, height, d
   html += '<td><input type="text" value="' + width + '" name="width_impact_' + id + '"></td>';
   html += '<td><input type="text" value="' + height + '" name="height_impact_' + id + '"></td>';
   html += '<td><input type="text" value="' + depth + '" name="depth_impact_' + id + '"></td>';
+  if (affectsView && window.product_images && window.product_images.length) {
+    html += '<td><select name="image_impact_' + id + '"><option value="0"></option>';
+    for (var i = 0; i < window.product_images.length; i++) {
+      var img = window.product_images[i];
+      var legend = img.legend ? img.legend : img.id_image;
+      html += '<option value="' + img.id_image + '">' + legend + '</option>';
+    }
+    html += '</select></td>';
+  } else if (affectsView) {
+    html += '<td></td>';
+  }
   html += '</tr>';
 
   return html;
@@ -172,7 +183,7 @@ function add_attr_multiple() {
       var name = elem.parentNode.getAttribute('name');
       target = $('#table_' + name);
       if (target && !getE('result_' + elem.getAttribute('name'))) {
-        newElem = create_attribute_row(elem.getAttribute('name'), elem.parentNode.getAttribute('name'), elem.value, '0.00', '0.00');
+        newElem = create_attribute_row(elem.getAttribute('name'), elem.parentNode.getAttribute('name'), elem.value, '0.00', '0.00', '0.00', '0.00', '0.00', elem.parentNode.getAttribute('data-affects-product-view'));
         target.append(newElem);
         toggle(target.parent()[0], true);
       }

--- a/tests/golden_files/db_schema.sql
+++ b/tests/golden_files/db_schema.sql
@@ -92,6 +92,7 @@ CREATE TABLE `PREFIX_attribute` (
 CREATE TABLE `PREFIX_attribute_group` (
   `id_attribute_group` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `is_color_group` tinyint(1) NOT NULL DEFAULT '0',
+  `affects_product_view` tinyint(1) NOT NULL DEFAULT '0',
   `group_type` enum('select','radio','color') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'select',
   `position` int(11) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_attribute_group`)


### PR DESCRIPTION
## Summary
- add `Affecting product view` switch to attribute groups
- show product images and allow assigning them to attributes in combinations generator
- reduce generator layout spacing and warn when no images uploaded

## Testing
- `php -l classes/AttributeGroup.php`
- `php -l controllers/admin/AdminAttributesGroupsController.php`
- `php -l controllers/admin/AdminAttributeGeneratorController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a85cd19ffc832da566f86bffc9b42f