### PR TITLE
Implement expiring password reset tokens

### DIFF
--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -128,6 +128,47 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                 ],
                 'submit' => ['title' => $this->l('Save')],
             ],
+            'password_reset' => [
+                'title'  => $this->l('Password reset tokens'),
+                'icon'   => 'icon-key',
+                'fields' => [
+                    'PS_PASSWD_RESET_TOKEN_LIFETIME' => [
+                        'title'      => $this->l('Token lifetime'),
+                        'validation' => 'isUnsignedInt',
+                        'cast'       => 'intval',
+                        'size'       => 5,
+                        'type'       => 'text',
+                        'suffix'     => $this->l('hours'),
+                    ],
+                    'PS_PASSWD_RESET_GUEST_TOKEN_LIFETIME' => [
+                        'title'      => $this->l('Guest conversion token lifetime'),
+                        'validation' => 'isUnsignedInt',
+                        'cast'       => 'intval',
+                        'size'       => 5,
+                        'type'       => 'text',
+                        'suffix'     => $this->l('hours'),
+                    ],
+                    'PS_PASSWD_RESET_ON_LOGIN' => [
+                        'title'      => $this->l('Reset token on login'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                    ],
+                    'PS_PASSWD_RESET_ON_REQUEST' => [
+                        'title'      => $this->l('Reset token on request'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                    ],
+                    'PS_PASSWD_RESET_ON_RESET' => [
+                        'title'      => $this->l('Reset token after password change'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                    ],
+                ],
+                'submit' => ['title' => $this->l('Save')],
+            ],
         ];
     }
 

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -376,6 +376,10 @@ class AuthControllerCore extends FrontController
 
                 Hook::triggerEvent('actionAuthentication', ['customer' => $this->context->customer]);
 
+                if (!Configuration::hasKey('PS_PASSWD_RESET_ON_LOGIN') || Configuration::get('PS_PASSWD_RESET_ON_LOGIN')) {
+                    $customer->clearResetPasswordToken();
+                }
+
                 // Login information have changed, so we check if the cart rules still apply
                 CartRule::autoRemoveFromCart($this->context);
                 CartRule::autoAddToCart($this->context);

--- a/mails/en/guest_to_customer.html
+++ b/mails/en/guest_to_customer.html
@@ -89,8 +89,8 @@
 						<span style="color:#777">
 							Your guest account for <span style="color:#333"><strong>{shop_name}</strong></span> was converted to a customer account. <br /><br />
 							<span style="color:#333"><strong>E-mail address:</strong></span> {email}<br /><br />
-							<span style="color:#333"><strong>Password:</strong></span> ******
-						</span>
+                                                         <span style="color:#333"><strong>To set your password:</strong></span> <a href="{url}" style="color:#337ff1">{url}</a>
+                                                </span>
 					</font>
 				</td>
 				<td width="10" style="padding:7px 0">&nbsp;</td>
@@ -100,14 +100,6 @@
 </tr>
 <tr>
 	<td class="space_footer" style="padding:0!important">&nbsp;</td>
-</tr>
-<tr>
-	<td class="linkbelow" style="padding:7px 0">
-		<font size="2" face="Open-sans, sans-serif" color="#555454">
-			<span>
-				Please be careful when sharing these login details with others.			</span>
-		</font>
-	</td>
 </tr>
 <tr>
 	<td class="linkbelow" style="padding:7px 0">

--- a/mails/en/guest_to_customer.txt
+++ b/mails/en/guest_to_customer.txt
@@ -8,9 +8,8 @@ account.
 
 E-MAIL ADDRESS: {email}
 
-PASSWORD: ******
-
-Please be careful when sharing these login details with others.
+To set your password, please use the following link:
+{url} [{url}]
 
 You can access your customer account on our shop: {shop_url}
 


### PR DESCRIPTION
## Summary
- Add reset_password_token and validity fields to customers with helper methods
- Replace secure key reset flow with expiring token links and optional token resets
- Send password setup link when guest is converted to customer
- Provide admin settings for token lifetime and reset behavior

## Testing
- `php -l classes/Customer.php`
- `php -l controllers/front/PasswordController.php`
- `php -l controllers/front/AuthController.php`
- `php -l controllers/admin/AdminCustomerPreferencesController.php`


------
https://chatgpt.com/codex/tasks/task_e_68aedb1b9a68832dbf21c76c3bb71ec8