### PR TITLE
Add token-based password reset mechanism

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -170,6 +170,9 @@ define('_PS_TMP_IMG_DIR_',          _PS_IMG_DIR_.'tmp/');
 /* settings php */
 define('_PS_TRANS_PATTERN_',            '(.*[^\\\\])');
 define('_PS_MIN_TIME_GENERATE_PASSWD_', '360');
+if (!defined('TB_PASSWD_RESET_TOKEN_VALIDITY')) {
+    define('TB_PASSWD_RESET_TOKEN_VALIDITY', 1440);
+}
 if ( ! defined('_TB_PRICE_DATABASE_PRECISION_')) {
     define('_TB_PRICE_DATABASE_PRECISION_', 6);
 }

--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -104,6 +104,15 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                         'type'       => 'text',
                         'suffix'     => $this->l('minutes'),
                     ],
+                    'TB_PASSWD_RESET_TOKEN_VALIDITY' => [
+                        'title'      => $this->l('Password reset link lifespan'),
+                        'hint'       => $this->l('How long the password reset link remains valid.'),
+                        'validation' => 'isUnsignedInt',
+                        'cast'       => 'intval',
+                        'size'       => 5,
+                        'type'       => 'text',
+                        'suffix'     => $this->l('minutes'),
+                    ],
                     'PS_B2B_ENABLE'                => [
                         'title'      => $this->l('Enable B2B mode'),
                         'hint'       => $this->l('Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.'),

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -68,7 +68,11 @@ class PasswordControllerCore extends FrontController
                 } elseif ((strtotime($customer->last_passwd_gen.'+'.($minTime = (int) Configuration::get('PS_PASSWD_TIME_FRONT')).' minutes') - time()) > 0) {
                     $this->errors[] = sprintf(Tools::displayError('You can regenerate your password only every %d minute(s)'), (int) $minTime);
                 } else {
-                    $url = $this->context->link->getPageLink('password', true, null, 'token='.$customer->secure_key.'&id_customer='.(int) $customer->id);
+                    if (!$customer->hasRecentResetPasswordToken()) {
+                        $customer->stampResetPasswordToken();
+                        $customer->update();
+                    }
+                    $url = $this->context->link->getPageLink('password', true, null, 'token='.$customer->secure_key.'&id_customer='.(int) $customer->id.'&reset_token='.$customer->reset_password_token);
                     $mailParams = [
                         '{email}'     => $customer->email,
                         '{lastname}'  => $customer->lastname,
@@ -142,6 +146,7 @@ class PasswordControllerCore extends FrontController
     {
         $customer->passwd = Tools::hash($password);
         $customer->last_passwd_gen = date('Y-m-d H:i:s', time());
+        $customer->removeResetPasswordToken();
         if ($customer->update()) {
             Hook::triggerEvent('actionPasswordRenew', [
                 'customer' => $customer,
@@ -182,7 +187,8 @@ class PasswordControllerCore extends FrontController
     {
         $token = Tools::getValue('token');
         $idCustomer = Tools::getIntValue('id_customer');
-        if ($token && $idCustomer) {
+        $resetToken = Tools::getValue('reset_token');
+        if ($token && $idCustomer && $resetToken) {
             $email = Db::readOnly()->getValue(
                 (new DbQuery())
                     ->select('c.`email`')
@@ -199,12 +205,15 @@ class PasswordControllerCore extends FrontController
                 if (!$customer->active) {
                     throw new PrestaShopException(Tools::displayError('You cannot regenerate the password for this account.'));
                 }
+                if ($customer->getValidResetPasswordToken() !== $resetToken) {
+                    throw new PrestaShopException(Tools::displayError('The password change request expired. You should ask for a new one.'));
+                }
                 return $customer;
             } else {
                 throw new PrestaShopException(Tools::displayError('We cannot regenerate your password with the data you\'ve submitted.'));
             }
         }
-        if ($token || $idCustomer) {
+        if ($token || $idCustomer || $resetToken) {
             throw new PrestaShopException(Tools::displayError('We cannot regenerate your password with the data you\'ve submitted.'));
         }
         return false;

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -140,6 +140,9 @@
     <configuration id="PS_PASSWD_TIME_FRONT" name="PS_PASSWD_TIME_FRONT">
       <value>360</value>
     </configuration>
+    <configuration id="TB_PASSWD_RESET_TOKEN_VALIDITY" name="TB_PASSWD_RESET_TOKEN_VALIDITY">
+      <value>1440</value>
+    </configuration>
     <configuration id="PS_DISP_UNAVAILABLE_ATTR" name="PS_DISP_UNAVAILABLE_ATTR">
       <value>1</value>
     </configuration>

--- a/tests/golden_files/db_schema.sql
+++ b/tests/golden_files/db_schema.sql
@@ -718,6 +718,8 @@ CREATE TABLE `PREFIX_customer` (
   `deleted` tinyint(1) NOT NULL DEFAULT '0',
   `date_add` datetime NOT NULL,
   `date_upd` datetime NOT NULL,
+  `reset_password_token` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `reset_password_validity` datetime DEFAULT NULL,
   PRIMARY KEY (`id_customer`),
   KEY `customer_email` (`email`),
   KEY `customer_login` (`email`,`passwd`),


### PR DESCRIPTION
## Summary
- introduce constant and configuration for password reset token lifetime
- extend customer model with reset token fields and helpers
- require and validate reset tokens in password reset controller and admin settings

## Testing
- `php -l config/defines.inc.php`
- `php -l classes/Customer.php`
- `php -l controllers/front/PasswordController.php`
- `php -l controllers/admin/AdminCustomerPreferencesController.php`
- `xmllint --noout install-dev/data/xml/configuration.xml`


------
https://chatgpt.com/codex/tasks/task_e_68af1c9137ec832dac63d67066c174e8