### PR TITLE
Implement token-based password reset mechanism

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -58,6 +58,10 @@ if (!defined('_PS_MODE_DEMO_')) {
     define('_PS_MODE_DEMO_', false);
 }
 
+if (!defined('TB_PASSWD_RESET_VALIDITY')) {
+    define('TB_PASSWD_RESET_VALIDITY', 1440);
+}
+
 if (!defined('PHP_VERSION_ID')) {
     $version = explode('.', PHP_VERSION);
     define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -68,7 +68,11 @@ class PasswordControllerCore extends FrontController
                 } elseif ((strtotime($customer->last_passwd_gen.'+'.($minTime = (int) Configuration::get('PS_PASSWD_TIME_FRONT')).' minutes') - time()) > 0) {
                     $this->errors[] = sprintf(Tools::displayError('You can regenerate your password only every %d minute(s)'), (int) $minTime);
                 } else {
-                    $url = $this->context->link->getPageLink('password', true, null, 'token='.$customer->secure_key.'&id_customer='.(int) $customer->id);
+                    if (!$customer->hasRecentResetPasswordToken()) {
+                        $customer->stampResetPasswordToken();
+                        $customer->update();
+                    }
+                    $url = $this->context->link->getPageLink('password', true, null, 'token='.$customer->secure_key.'&id_customer='.(int)$customer->id.'&reset_token='.$customer->reset_password_token);
                     $mailParams = [
                         '{email}'     => $customer->email,
                         '{lastname}'  => $customer->lastname,
@@ -142,6 +146,7 @@ class PasswordControllerCore extends FrontController
     {
         $customer->passwd = Tools::hash($password);
         $customer->last_passwd_gen = date('Y-m-d H:i:s', time());
+        $customer->removeResetPasswordToken();
         if ($customer->update()) {
             Hook::triggerEvent('actionPasswordRenew', [
                 'customer' => $customer,
@@ -182,7 +187,8 @@ class PasswordControllerCore extends FrontController
     {
         $token = Tools::getValue('token');
         $idCustomer = Tools::getIntValue('id_customer');
-        if ($token && $idCustomer) {
+        $resetToken = Tools::getValue('reset_token');
+        if ($token && $idCustomer && $resetToken) {
             $email = Db::readOnly()->getValue(
                 (new DbQuery())
                     ->select('c.`email`')
@@ -199,13 +205,16 @@ class PasswordControllerCore extends FrontController
                 if (!$customer->active) {
                     throw new PrestaShopException(Tools::displayError('You cannot regenerate the password for this account.'));
                 }
+                if ($customer->getValidResetPasswordToken() !== $resetToken) {
+                    throw new PrestaShopException(Tools::displayError("We cannot regenerate your password with the data you've submitted."));
+                }
                 return $customer;
             } else {
                 throw new PrestaShopException(Tools::displayError('We cannot regenerate your password with the data you\'ve submitted.'));
             }
         }
-        if ($token || $idCustomer) {
-            throw new PrestaShopException(Tools::displayError('We cannot regenerate your password with the data you\'ve submitted.'));
+        if ($token || $idCustomer || $resetToken) {
+            throw new PrestaShopException(Tools::displayError("We cannot regenerate your password with the data you've submitted."));
         }
         return false;
     }


### PR DESCRIPTION
## Summary
- add TB_PASSWD_RESET_VALIDITY constant for reset token lifetime
- support reset password tokens for customers and employees
- send reset links and handle token-based password update

## Testing
- `php -l config/defines.inc.php`
- `php -l classes/Employee.php`
- `php -l classes/Customer.php`
- `php -l controllers/front/PasswordController.php`
- `php -l controllers/admin/AdminLoginController.php`
- `./vendor/bin/codecept run Unit -c codeception.yml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af1c9137ec832dac63d67066c174e8