### PR TITLE
feat: add secure rotating tokens for password reset

### DIFF
--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -128,6 +128,31 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                 ],
                 'submit' => ['title' => $this->l('Save')],
             ],
+            'passwordreset' => [
+                'title' => $this->l('Password reset'),
+                'icon'  => 'icon-key',
+                'fields' => [
+                    'PS_PASSWD_RESET_TOKEN_LIFETIME' => [
+                        'title'      => $this->l('Reset token lifetime'),
+                        'hint'       => $this->l('Number of minutes a password reset token remains valid.'),
+                        'validation' => 'isUnsignedInt',
+                        'cast'       => 'intval',
+                        'size'       => 5,
+                        'type'       => 'text',
+                        'suffix'     => $this->l('minutes'),
+                    ],
+                    'PS_PASSWD_GUEST_TO_CUSTOMER_TOKEN_LIFETIME' => [
+                        'title'      => $this->l('Guest to customer token lifetime'),
+                        'hint'       => $this->l('Number of minutes a guest to customer token remains valid.'),
+                        'validation' => 'isUnsignedInt',
+                        'cast'       => 'intval',
+                        'size'       => 5,
+                        'type'       => 'text',
+                        'suffix'     => $this->l('minutes'),
+                    ],
+                ],
+                'submit' => ['title' => $this->l('Save')],
+            ],
         ];
     }
 

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -351,6 +351,9 @@ class AuthControllerCore extends FrontController
 
                 // Add customer to the context
                 $this->context->customer = $customer;
+                if ($customer->reset_password_token) {
+                    $customer->clearResetPasswordToken();
+                }
 
                 if (Configuration::get('PS_CART_FOLLOWING') && (empty($this->context->cookie->id_cart) || Cart::getNbProducts($this->context->cookie->id_cart) == 0) && $idCart = (int) Cart::lastNoneOrderedCart($this->context->customer->id)) {
                     $this->context->cart = new Cart($idCart);

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -140,6 +140,12 @@
     <configuration id="PS_PASSWD_TIME_FRONT" name="PS_PASSWD_TIME_FRONT">
       <value>360</value>
     </configuration>
+    <configuration id="PS_PASSWD_RESET_TOKEN_LIFETIME" name="PS_PASSWD_RESET_TOKEN_LIFETIME">
+      <value>60</value>
+    </configuration>
+    <configuration id="PS_PASSWD_GUEST_TO_CUSTOMER_TOKEN_LIFETIME" name="PS_PASSWD_GUEST_TO_CUSTOMER_TOKEN_LIFETIME">
+      <value>2880</value>
+    </configuration>
     <configuration id="PS_DISP_UNAVAILABLE_ATTR" name="PS_DISP_UNAVAILABLE_ATTR">
       <value>1</value>
     </configuration>

--- a/mails/en/password_query.html
+++ b/mails/en/password_query.html
@@ -87,9 +87,9 @@
 						<p data-html-only="1" style="border-bottom:1px solid #D6D4D4;margin:3px 0 7px;text-transform:uppercase;font-weight:500;font-size:18px;padding-bottom:10px">
 							Password reset request for {shop_name}						</p>
 						<span style="color:#777">
-							You have requested to reset your <span style="color:#333"><strong>{shop_name}</strong></span> login details.<br/><br/>
-							Please note that this will change your current password.<br/><br/>
-							To confirm this action, please use the following link: <br /> <a href="{url}" style="color:#337ff1">{url}</a>
+                                                        You have requested to reset your <span style="color:#333"><strong>{shop_name}</strong></span> login details.<br/><br/>
+                                                        This link will expire in {token_validity} hour(s).<br/><br/>
+                                                        To confirm this action, please use the following link: <br /> <a href="{url}" style="color:#337ff1">{url}</a>
 						</span>
 					</font>
 				</td>

--- a/mails/en/password_query.txt
+++ b/mails/en/password_query.txt
@@ -5,7 +5,7 @@ Hi {firstname} {lastname},
 
 You have requested to reset your {shop_name} login details.
 
-Please note that this will change your current password.
+This link will expire in {token_validity} hour(s).
 
 To confirm this action, please use the following link:
 


### PR DESCRIPTION
## Summary
- generate cryptographically secure reset tokens stored in customer table
- add admin options for token lifetimes and update mail templates
- clear reset tokens on login and password change

## Testing
- `php -l classes/Customer.php`
- `php -l controllers/admin/AdminCustomerPreferencesController.php`
- `php -l controllers/front/AuthController.php`
- `php -l controllers/front/PasswordController.php`


------
https://chatgpt.com/codex/tasks/task_e_68af782498e0832dae297addb545e3a0