### PR TITLE
feat: add secure password reset tokens

### DIFF
--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -128,6 +128,31 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                 ],
                 'submit' => ['title' => $this->l('Save')],
             ],
+            'password_reset' => [
+                'title' => $this->l('Password reset tokens'),
+                'icon'  => 'icon-key',
+                'fields' => [
+                    'PS_PASSWD_RESET_TOKEN_TTL' => [
+                        'title'      => $this->l('Customer token lifetime'),
+                        'hint'       => $this->l('Validity of password reset tokens in minutes.'),
+                        'validation' => 'isUnsignedInt',
+                        'cast'       => 'intval',
+                        'type'       => 'text',
+                        'size'       => 5,
+                        'suffix'     => $this->l('minutes'),
+                    ],
+                    'PS_GUEST_PASSWD_RESET_TOKEN_TTL' => [
+                        'title'      => $this->l('Guest token lifetime'),
+                        'hint'       => $this->l('Validity of guest-to-customer tokens in minutes.'),
+                        'validation' => 'isUnsignedInt',
+                        'cast'       => 'intval',
+                        'type'       => 'text',
+                        'size'       => 5,
+                        'suffix'     => $this->l('minutes'),
+                    ],
+                ],
+                'submit' => ['title' => $this->l('Save')],
+            ],
         ];
     }
 

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -351,6 +351,7 @@ class AuthControllerCore extends FrontController
 
                 // Add customer to the context
                 $this->context->customer = $customer;
+                $customer->clearResetPasswordToken();
 
                 if (Configuration::get('PS_CART_FOLLOWING') && (empty($this->context->cookie->id_cart) || Cart::getNbProducts($this->context->cookie->id_cart) == 0) && $idCart = (int) Cart::lastNoneOrderedCart($this->context->customer->id)) {
                     $this->context->cart = new Cart($idCart);

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -140,6 +140,12 @@
     <configuration id="PS_PASSWD_TIME_FRONT" name="PS_PASSWD_TIME_FRONT">
       <value>360</value>
     </configuration>
+    <configuration id="PS_PASSWD_RESET_TOKEN_TTL" name="PS_PASSWD_RESET_TOKEN_TTL">
+      <value>60</value>
+    </configuration>
+    <configuration id="PS_GUEST_PASSWD_RESET_TOKEN_TTL" name="PS_GUEST_PASSWD_RESET_TOKEN_TTL">
+      <value>2880</value>
+    </configuration>
     <configuration id="PS_DISP_UNAVAILABLE_ATTR" name="PS_DISP_UNAVAILABLE_ATTR">
       <value>1</value>
     </configuration>

--- a/mails/en/password_query.html
+++ b/mails/en/password_query.html
@@ -89,12 +89,13 @@
 						<span style="color:#777">
 							You have requested to reset your <span style="color:#333"><strong>{shop_name}</strong></span> login details.<br/><br/>
 							Please note that this will change your current password.<br/><br/>
-							To confirm this action, please use the following link: <br /> <a href="{url}" style="color:#337ff1">{url}</a>
-						</span>
-					</font>
-				</td>
-				<td width="10" style="padding:7px 0">&nbsp;</td>
-			</tr>
+                                                        To confirm this action, please use the following link: <br /> <a href="{url}" style="color:#337ff1">{url}</a><br/><br/>
+                                                        This link will expire in {token_validity} hour(s).
+                                                </span>
+                                        </font>
+                                </td>
+                                <td width="10" style="padding:7px 0">&nbsp;</td>
+                        </tr>
 		</table>
 	</td>
 </tr>

--- a/mails/en/password_query.txt
+++ b/mails/en/password_query.txt
@@ -11,5 +11,7 @@ To confirm this action, please use the following link:
 
 {url} [{url}]
 
+This link will expire in {token_validity} hour(s).
+
 {shop_name} [{shop_url}]
 


### PR DESCRIPTION
## Summary
- use rotating cryptographic tokens for front-office password resets
- configure reset token lifetimes in Customer Preferences
- add audit logging and token expiry notice in reset emails

## Testing
- `php -l classes/Customer.php controllers/front/PasswordController.php controllers/front/AuthController.php controllers/admin/AdminCustomerPreferencesController.php`
- `composer install --no-interaction` *(fails: Composer could not find a composer.json file)*
- `vendor/bin/codecept run Unit` *(fails: vendor/bin/codecept: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af782498e0832dae297addb545e3a0