### PR TITLE
feat(password-reset): add rotating tokens

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -65,6 +65,8 @@ class CustomerCore extends ObjectModel
             'show_public_prices'         => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'copy_post' => false, 'dbDefault' => '0'],
             'max_payment_days'           => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'copy_post' => false, 'dbDefault' => '60'],
             'secure_key'                 => ['type' => self::TYPE_STRING, 'validate' => 'isMd5', 'copy_post' => false, 'size' => 32, 'dbDefault' => '-1'],
+            'reset_password_token'       => ['type' => self::TYPE_STRING, 'size' => 64, 'copy_post' => false],
+            'reset_password_validity'    => ['type' => self::TYPE_DATE, 'dbType' => 'datetime', 'copy_post' => false, 'dbNullable' => true],
             'note'                       => ['type' => self::TYPE_HTML, 'validate' => 'isCleanHtml', 'copy_post' => false, 'size' => ObjectModel::SIZE_TEXT],
             'active'                     => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'copy_post' => false, 'dbDefault' => '0'],
             'is_guest'                   => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'copy_post' => false, 'dbType' => 'tinyint(1)', 'dbDefault' => '0'],
@@ -80,6 +82,7 @@ class CustomerCore extends ObjectModel
                 'id_gender'          => ['type' => ObjectModel::KEY, 'columns' => ['id_gender']],
                 'id_shop'            => ['type' => ObjectModel::KEY, 'columns' => ['id_shop', 'date_add']],
                 'id_shop_group'      => ['type' => ObjectModel::KEY, 'columns' => ['id_shop_group']],
+                'reset_password_token' => ['type' => ObjectModel::KEY, 'columns' => ['reset_password_token']],
             ],
         ],
     ];
@@ -175,6 +178,12 @@ class CustomerCore extends ObjectModel
     public $date_add;
     /** @var string Object last modification date */
     public $date_upd;
+
+    /** @var string Password reset token */
+    public $reset_password_token;
+
+    /** @var string Password reset token validity */
+    public $reset_password_validity;
 
     /**
      * @var int
@@ -1386,5 +1395,26 @@ class CustomerCore extends ObjectModel
         // delete source customer
         $source->delete();
 
+    }
+
+    /**
+     * Assigns new password reset token and validity
+     *
+     * @param string $token Plain token
+     * @param int $lifetime Lifetime in seconds
+     */
+    public function setResetPasswordToken($token, $lifetime)
+    {
+        $this->reset_password_token = hash('sha256', $token);
+        $this->reset_password_validity = date('Y-m-d H:i:s', time() + (int)$lifetime);
+    }
+
+    /**
+     * Clears password reset token
+     */
+    public function clearResetPasswordToken()
+    {
+        $this->reset_password_token = null;
+        $this->reset_password_validity = null;
     }
 }

--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -135,6 +135,7 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                 'PS_PASSWD_TIME_FRONT'         => [
                     'title'      => $this->l('Password reset delay'),
                     'hint'       => $this->l('Minimum time required between two requests for a password reset.'),
+                    'desc'       => $this->l('Assign minimum time (in minutes) between two password reset attempts. Use only if you notice lots of spam in this function in your Advanced Parameter - Logs section.'),
                     'validation' => 'isUnsignedInt',
                     'cast'       => 'intval',
                     'size'       => 5,
@@ -144,7 +145,7 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                 'TB_PASSWD_RESET_TOKEN_TTL' => [
                     'title'      => $this->l('Password reset token lifetime'),
                     'hint'       => $this->l('Lifetime in hours of the password reset token.'),
-                    'desc'       => $this->l('Tokens expire after this delay and the value must be greater than 0.'),
+                    'desc'       => $this->l('Tokens expire after this delay. Enter a whole number of hours (minimum 1).'),
                     'validation' => 'isUnsignedInt',
                     'cast'       => 'intval',
                     'size'       => 5,
@@ -154,7 +155,7 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                 'TB_GUEST_TO_CUSTOMER_TOKEN_TTL' => [
                     'title'      => $this->l('Guest to customer token lifetime'),
                     'hint'       => $this->l('Lifetime in hours of guest to customer tokens.'),
-                    'desc'       => $this->l('Tokens expire after this delay and the value must be greater than 0.'),
+                    'desc'       => $this->l('Tokens expire after this delay. Enter a whole number of hours (minimum 1).'),
                     'validation' => 'isUnsignedInt',
                     'cast'       => 'intval',
                     'size'       => 5,

--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -129,6 +129,39 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                 'submit' => ['title' => $this->l('Save')],
             ],
         ];
+
+        if (!Configuration::hasKey('TB_PASSWD_RESET_TOKEN_TTL')) {
+            Configuration::updateValue('TB_PASSWD_RESET_TOKEN_TTL', 1);
+        }
+        if (!Configuration::hasKey('TB_GUEST_TO_CUSTOMER_TOKEN_TTL')) {
+            Configuration::updateValue('TB_GUEST_TO_CUSTOMER_TOKEN_TTL', 48);
+        }
+
+        $this->fields_options['password_reset'] = [
+            'title'  => $this->l('Password reset'),
+            'icon'   => 'icon-unlock',
+            'fields' => [
+                'TB_PASSWD_RESET_TOKEN_TTL' => [
+                    'title'      => $this->l('Password reset token lifetime'),
+                    'hint'       => $this->l('Lifetime in hours of the password reset token.'),
+                    'validation' => 'isUnsignedInt',
+                    'cast'       => 'intval',
+                    'size'       => 5,
+                    'type'       => 'text',
+                    'suffix'     => $this->l('hours'),
+                ],
+                'TB_GUEST_TO_CUSTOMER_TOKEN_TTL' => [
+                    'title'      => $this->l('Guest to customer token lifetime'),
+                    'hint'       => $this->l('Lifetime in hours of guest to customer tokens.'),
+                    'validation' => 'isUnsignedInt',
+                    'cast'       => 'intval',
+                    'size'       => 5,
+                    'type'       => 'text',
+                    'suffix'     => $this->l('hours'),
+                ],
+            ],
+            'submit' => ['title' => $this->l('Save')],
+        ];
     }
 
     /**

--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -95,15 +95,6 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                         'cast'       => 'intval',
                         'type'       => 'bool',
                     ],
-                    'PS_PASSWD_TIME_FRONT'         => [
-                        'title'      => $this->l('Password reset delay'),
-                        'hint'       => $this->l('Minimum time required between two requests for a password reset.'),
-                        'validation' => 'isUnsignedInt',
-                        'cast'       => 'intval',
-                        'size'       => 5,
-                        'type'       => 'text',
-                        'suffix'     => $this->l('minutes'),
-                    ],
                     'PS_B2B_ENABLE'                => [
                         'title'      => $this->l('Enable B2B mode'),
                         'hint'       => $this->l('Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.'),
@@ -141,9 +132,19 @@ class AdminCustomerPreferencesControllerCore extends AdminController
             'title'  => $this->l('Password reset'),
             'icon'   => 'icon-unlock',
             'fields' => [
+                'PS_PASSWD_TIME_FRONT'         => [
+                    'title'      => $this->l('Password reset delay'),
+                    'hint'       => $this->l('Minimum time required between two requests for a password reset.'),
+                    'validation' => 'isUnsignedInt',
+                    'cast'       => 'intval',
+                    'size'       => 5,
+                    'type'       => 'text',
+                    'suffix'     => $this->l('minutes'),
+                ],
                 'TB_PASSWD_RESET_TOKEN_TTL' => [
                     'title'      => $this->l('Password reset token lifetime'),
                     'hint'       => $this->l('Lifetime in hours of the password reset token.'),
+                    'desc'       => $this->l('Tokens expire after this delay and the value must be greater than 0.'),
                     'validation' => 'isUnsignedInt',
                     'cast'       => 'intval',
                     'size'       => 5,
@@ -153,6 +154,7 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                 'TB_GUEST_TO_CUSTOMER_TOKEN_TTL' => [
                     'title'      => $this->l('Guest to customer token lifetime'),
                     'hint'       => $this->l('Lifetime in hours of guest to customer tokens.'),
+                    'desc'       => $this->l('Tokens expire after this delay and the value must be greater than 0.'),
                     'validation' => 'isUnsignedInt',
                     'cast'       => 'intval',
                     'size'       => 5,
@@ -187,5 +189,31 @@ class AdminCustomerPreferencesControllerCore extends AdminController
             }
         }
         Configuration::updateValue('PS_B2B_ENABLE', $value);
+    }
+
+    /**
+     * @return bool
+     */
+    public function postProcess()
+    {
+        if (Tools::isSubmit('submitOptionsconfiguration')) {
+            if (Tools::getIsset('TB_PASSWD_RESET_TOKEN_TTL')) {
+                $resetTtl = (int) Tools::getValue('TB_PASSWD_RESET_TOKEN_TTL');
+                if ($resetTtl < 1) {
+                    $this->errors[] = $this->l('Password reset token lifetime must be greater than 0.');
+                }
+            }
+            if (Tools::getIsset('TB_GUEST_TO_CUSTOMER_TOKEN_TTL')) {
+                $guestTtl = (int) Tools::getValue('TB_GUEST_TO_CUSTOMER_TOKEN_TTL');
+                if ($guestTtl < 1) {
+                    $this->errors[] = $this->l('Guest to customer token lifetime must be greater than 0.');
+                }
+            }
+            if (count($this->errors)) {
+                return false;
+            }
+        }
+
+        return parent::postProcess();
     }
 }

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -350,6 +350,8 @@ class AuthControllerCore extends FrontController
                 $this->context->cookie->email = $customer->email;
 
                 // Add customer to the context
+                $customer->clearResetPasswordToken();
+                $customer->update();
                 $this->context->customer = $customer;
 
                 if (Configuration::get('PS_CART_FOLLOWING') && (empty($this->context->cookie->id_cart) || Cart::getNbProducts($this->context->cookie->id_cart) == 0) && $idCart = (int) Cart::lastNoneOrderedCart($this->context->customer->id)) {

--- a/controllers/front/GuestTrackingController.php
+++ b/controllers/front/GuestTrackingController.php
@@ -104,19 +104,13 @@ class GuestTrackingControllerCore extends FrontController
 
             // process transformation to customer account
             if (Tools::isSubmit('submitTransformGuestToCustomer')) {
-                $password = Tools::getValue('password');
-                if (! Validate::isPasswd($password)) {
-                    $this->errors[] = Tools::displayError('Please use stronger password');
-                    return;
-                }
-
                 $customer = new Customer((int) $order->id_customer);
                 if (!Validate::isLoadedObject($customer)) {
                     $this->errors[] = Tools::displayError('Invalid customer');
                     return;
                 }
 
-                if (! $customer->transformToCustomer($this->context->language->id, Tools::getValue('password'))) {
+                if (! $customer->transformToCustomer($this->context->language->id)) {
                     $this->errors[] = Tools::displayError('An error occurred while transforming a guest into a registered customer.');
                 } else {
                     $this->context->smarty->assign('transformSuccess', true);

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -78,6 +78,10 @@ class PasswordControllerCore extends FrontController
                     $token = bin2hex(Tools::getBytes(32));
                     $customer->setResetPasswordToken($token, $tokenLifetime * 3600);
                     if ($customer->update()) {
+                        $ip = Tools::getRemoteAddr();
+                        $ua = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : 'unknown';
+                        PrestaShopLogger::addLog('Password reset token issued for '.$customer->email.' from '.$ip.' ['.$ua.']', 1, null, 'Customer', (int)$customer->id);
+
                         $url = $this->context->link->getPageLink('password', true, null, 'token='.$token);
                         $mailParams = [
                             '{email}'           => $customer->email,
@@ -86,11 +90,7 @@ class PasswordControllerCore extends FrontController
                             '{url}'             => $url,
                             '{token_lifetime}'  => $tokenLifetime,
                         ];
-                        if (Mail::Send($this->context->language->id, 'password_query', Mail::l('Password query confirmation'), $mailParams, $customer->email, $customer->firstname.' '.$customer->lastname)) {
-                            $ip = Tools::getRemoteAddr();
-                            $ua = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : 'unknown';
-                            PrestaShopLogger::addLog('Password reset token issued for '.$customer->email.' from '.$ip.' ['.$ua.']', 1, null, 'Customer', (int) $customer->id);
-                        }
+                        Mail::Send($this->context->language->id, 'password_query', Mail::l('Password query confirmation'), $mailParams, $customer->email, $customer->firstname.' '.$customer->lastname);
                     }
                 }
 

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -137,7 +137,10 @@ class PasswordControllerCore extends FrontController
     {
         parent::initContent();
         if ($customer = $this->getCustomer()) {
-            $this->context->smarty->assign(['customer' => $customer]);
+            $this->context->smarty->assign([
+                'customer' => $customer,
+                'token'    => Tools::getValue('token'),
+            ]);
             $this->setTemplate(_PS_THEME_DIR_.'password-set.tpl');
         } else {
             $this->setTemplate(_PS_THEME_DIR_.'password.tpl');

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -60,30 +60,43 @@ class PasswordControllerCore extends FrontController
                 $this->errors[] = Tools::displayError('Invalid email address.');
             } else {
                 $customer = new Customer();
-                $customer->getByemail($email);
-                if (!Validate::isLoadedObject($customer)) {
-                    $this->errors[] = Tools::displayError('There is no account registered for this email address.');
-                } elseif (!$customer->active) {
-                    $this->errors[] = Tools::displayError('You cannot regenerate the password for this account.');
+                $customer->getByEmail($email);
+
+                $tokenLifetime = (int) Configuration::get('TB_PASSWD_RESET_TOKEN_TTL');
+                if ($tokenLifetime <= 0) {
+                    $tokenLifetime = 1;
+                }
+
+                $shouldSend = true;
+                if (!Validate::isLoadedObject($customer) || !$customer->active) {
+                    $shouldSend = false;
                 } elseif ((strtotime($customer->last_passwd_gen.'+'.($minTime = (int) Configuration::get('PS_PASSWD_TIME_FRONT')).' minutes') - time()) > 0) {
-                    $this->errors[] = sprintf(Tools::displayError('You can regenerate your password only every %d minute(s)'), (int) $minTime);
-                } else {
-                    $url = $this->context->link->getPageLink('password', true, null, 'token='.$customer->secure_key.'&id_customer='.(int) $customer->id);
-                    $mailParams = [
-                        '{email}'     => $customer->email,
-                        '{lastname}'  => $customer->lastname,
-                        '{firstname}' => $customer->firstname,
-                        '{url}'       => $url,
-                    ];
-                    if (Mail::Send($this->context->language->id, 'password_query', Mail::l('Password query confirmation'), $mailParams, $customer->email, $customer->firstname.' '.$customer->lastname)) {
-                        $this->context->smarty->assign([
-                            'confirmation' => 2,
-                            'customer_email' => $customer->email
-                        ]);
-                    } else {
-                        $this->errors[] = Tools::displayError('An error occurred while sending the email.');
+                    $shouldSend = false;
+                }
+
+                if ($shouldSend) {
+                    $token = bin2hex(Tools::getBytes(32));
+                    $customer->setResetPasswordToken($token, $tokenLifetime * 3600);
+                    if ($customer->update()) {
+                        $url = $this->context->link->getPageLink('password', true, null, 'token='.$token);
+                        $mailParams = [
+                            '{email}'           => $customer->email,
+                            '{lastname}'        => $customer->lastname,
+                            '{firstname}'       => $customer->firstname,
+                            '{url}'             => $url,
+                            '{token_lifetime}'  => $tokenLifetime,
+                        ];
+                        if (Mail::Send($this->context->language->id, 'password_query', Mail::l('Password query confirmation'), $mailParams, $customer->email, $customer->firstname.' '.$customer->lastname)) {
+                            $ip = Tools::getRemoteAddr();
+                            $ua = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : 'unknown';
+                            PrestaShopLogger::addLog('Password reset token issued for '.$customer->email.' from '.$ip.' ['.$ua.']', 1, null, 'Customer', (int) $customer->id);
+                        }
                     }
                 }
+
+                $this->context->smarty->assign([
+                    'confirmation' => 2,
+                ]);
             }
             if ($this->ajax) {
                 $return = [
@@ -147,6 +160,8 @@ class PasswordControllerCore extends FrontController
                 'customer' => $customer,
                 'password' => $password
             ]);
+            $customer->clearResetPasswordToken();
+            $customer->update();
             $this->context->smarty->assign(['confirmation' => 1]);
         } else {
             $this->errors[] = Tools::displayError('An error occurred with your account, which prevents us from sending you a new password. Please report this issue using the contact form.');
@@ -181,30 +196,25 @@ class PasswordControllerCore extends FrontController
     protected static function resolveCustomer()
     {
         $token = Tools::getValue('token');
-        $idCustomer = Tools::getIntValue('id_customer');
-        if ($token && $idCustomer) {
-            $email = Db::readOnly()->getValue(
+        if ($token) {
+            $hash = hash('sha256', $token);
+            $data = Db::readOnly()->getRow(
                 (new DbQuery())
-                    ->select('c.`email`')
+                    ->select('c.`id_customer`, c.`reset_password_validity`')
                     ->from('customer', 'c')
-                    ->where('c.`secure_key` = \''.pSQL($token).'\'')
-                    ->where('c.`id_customer` = '.(int) $idCustomer)
+                    ->where('c.`reset_password_token` = \''.pSQL($hash).'\'')
             );
-            if ($email) {
-                $customer = new Customer();
-                $customer->getByemail($email);
-                if (!Validate::isLoadedObject($customer)) {
-                    throw new PrestaShopException(Tools::displayError('Customer account not found'));
+            if ($data) {
+                if (strtotime($data['reset_password_validity']) >= time()) {
+                    $customer = new Customer((int)$data['id_customer']);
+                    if (!$customer->active) {
+                        throw new PrestaShopException(Tools::displayError('You cannot regenerate the password for this account.'));
+                    }
+                    return $customer;
                 }
-                if (!$customer->active) {
-                    throw new PrestaShopException(Tools::displayError('You cannot regenerate the password for this account.'));
-                }
-                return $customer;
-            } else {
-                throw new PrestaShopException(Tools::displayError('We cannot regenerate your password with the data you\'ve submitted.'));
+                Db::getInstance()->update('customer', ['reset_password_token' => null, 'reset_password_validity' => null], 'id_customer='.(int)$data['id_customer']);
+                throw new PrestaShopException(Tools::displayError('This password reset link has expired.'));
             }
-        }
-        if ($token || $idCustomer) {
             throw new PrestaShopException(Tools::displayError('We cannot regenerate your password with the data you\'ve submitted.'));
         }
         return false;

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -80,7 +80,14 @@ class PasswordControllerCore extends FrontController
                     if ($customer->update()) {
                         $ip = Tools::getRemoteAddr();
                         $ua = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : 'unknown';
-                        PrestaShopLogger::addLog('Password reset token issued for '.$customer->email.' from '.$ip.' ['.$ua.']', 1, null, 'Customer', (int)$customer->id);
+                        Logger::addLog(
+                            'Password reset token issued for '.$customer->email.' from '.$ip.' ['.$ua.']',
+                            1,
+                            null,
+                            'Customer',
+                            (int)$customer->id,
+                            true
+                        );
 
                         $url = $this->context->link->getPageLink('password', true, null, 'token='.$token);
                         $mailParams = [

--- a/mails/en/guest_to_customer.html
+++ b/mails/en/guest_to_customer.html
@@ -88,13 +88,13 @@
 							Your customer account creation						</p>
 						<span style="color:#777">
 							Your guest account for <span style="color:#333"><strong>{shop_name}</strong></span> was converted to a customer account. <br /><br />
-							<span style="color:#333"><strong>E-mail address:</strong></span> {email}<br /><br />
-							<span style="color:#333"><strong>Password:</strong></span> ******
-						</span>
-					</font>
-				</td>
-				<td width="10" style="padding:7px 0">&nbsp;</td>
-			</tr>
+                                                        To set your password, please use the following link: <br /> <a href="{url}" style="color:#337ff1">{url}</a><br /><br />
+                                                        This link is valid for {token_lifetime} hour(s).
+                                                </span>
+                                        </font>
+                                </td>
+                                <td width="10" style="padding:7px 0">&nbsp;</td>
+                        </tr>
 		</table>
 	</td>
 </tr>
@@ -105,7 +105,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				Please be careful when sharing these login details with others.			</span>
+				Please be careful when sharing this link with others.			</span>
 		</font>
 	</td>
 </tr>
@@ -113,7 +113,7 @@
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
 			<span>
-				You can access your customer account on our shop: <strong>{shop_url}</strong>
+				You can access your customer account on our shop after setting your password: <strong>{shop_url}</strong>
 			</span>
 		</font>
 	</td>

--- a/mails/en/guest_to_customer.txt
+++ b/mails/en/guest_to_customer.txt
@@ -6,13 +6,14 @@ Hi {firstname} {lastname},
 Your guest account for {shop_name} was converted to a customer
 account.
 
-E-MAIL ADDRESS: {email}
+To set your password, please use the following link:
+{url}
 
-PASSWORD: ******
+This link is valid for {token_lifetime} hour(s).
 
-Please be careful when sharing these login details with others.
+Please be careful when sharing this link with others.
 
-You can access your customer account on our shop: {shop_url}
+You can access your customer account on our shop after setting your password: {shop_url}
 
 {shop_name} [{shop_url}]
 

--- a/mails/en/password_query.html
+++ b/mails/en/password_query.html
@@ -87,13 +87,14 @@
 						<p data-html-only="1" style="border-bottom:1px solid #D6D4D4;margin:3px 0 7px;text-transform:uppercase;font-weight:500;font-size:18px;padding-bottom:10px">
 							Password reset request for {shop_name}						</p>
 						<span style="color:#777">
-							You have requested to reset your <span style="color:#333"><strong>{shop_name}</strong></span> login details.<br/><br/>
-							Please note that this will change your current password.<br/><br/>
-							To confirm this action, please use the following link: <br /> <a href="{url}" style="color:#337ff1">{url}</a>
-						</span>
-					</font>
-				</td>
-				<td width="10" style="padding:7px 0">&nbsp;</td>
+                                                        You have requested to reset your <span style="color:#333"><strong>{shop_name}</strong></span> login details.<br/><br/>
+                                                        Please note that this will change your current password.<br/><br/>
+                                                        This link is valid for {token_lifetime} hour(s).<br/><br/>
+                                                        To confirm this action, please use the following link: <br /> <a href="{url}" style="color:#337ff1">{url}</a>
+                                                </span>
+                                        </font>
+                                </td>
+                                <td width="10" style="padding:7px 0">&nbsp;</td>
 			</tr>
 		</table>
 	</td>

--- a/mails/en/password_query.txt
+++ b/mails/en/password_query.txt
@@ -7,6 +7,8 @@ You have requested to reset your {shop_name} login details.
 
 Please note that this will change your current password.
 
+This link is valid for {token_lifetime} hour(s).
+
 To confirm this action, please use the following link:
 
 {url} [{url}]

--- a/tests/golden_files/db_schema.sql
+++ b/tests/golden_files/db_schema.sql
@@ -712,6 +712,8 @@ CREATE TABLE `PREFIX_customer` (
   `show_public_prices` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `max_payment_days` int(11) unsigned NOT NULL DEFAULT '60',
   `secure_key` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '-1',
+  `reset_password_token` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `reset_password_validity` datetime DEFAULT NULL,
   `note` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `is_guest` tinyint(1) NOT NULL DEFAULT '0',
@@ -724,7 +726,8 @@ CREATE TABLE `PREFIX_customer` (
   KEY `id_customer_passwd` (`id_customer`,`passwd`),
   KEY `id_gender` (`id_gender`),
   KEY `id_shop` (`id_shop`,`date_add`),
-  KEY `id_shop_group` (`id_shop_group`)
+  KEY `id_shop_group` (`id_shop_group`),
+  KEY `reset_password_token` (`reset_password_token`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `PREFIX_customer_group` (


### PR DESCRIPTION
## Summary
- use cryptographically secure single-use tokens for password resets
- allow admin to configure token lifetimes
- update password reset email templates

## Testing
- `php -l classes/Customer.php`
- `php -l controllers/front/PasswordController.php`
- `php -l controllers/front/AuthController.php`
- `php -l controllers/admin/AdminCustomerPreferencesController.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af782498e0832dae297addb545e3a0