### PR TITLE
feat: add secure rotating password reset tokens

### DIFF
--- a/controllers/admin/AdminCustomerPreferencesController.php
+++ b/controllers/admin/AdminCustomerPreferencesController.php
@@ -128,6 +128,38 @@ class AdminCustomerPreferencesControllerCore extends AdminController
                 ],
                 'submit' => ['title' => $this->l('Save')],
             ],
+            'password_reset' => [
+                'title'  => $this->l('Password reset'),
+                'icon'   => 'icon-key',
+                'fields' => [
+                    'TB_PASSWD_RESET_TOKEN_LIFETIME' => [
+                        'title'      => $this->l('Reset token lifetime'),
+                        'hint'       => $this->l('Minutes before a password reset token expires.'),
+                        'validation' => 'isUnsignedInt',
+                        'cast'       => 'intval',
+                        'size'       => 5,
+                        'type'       => 'text',
+                        'suffix'     => $this->l('minutes'),
+                    ],
+                    'TB_PASSWD_GUEST_TOKEN_LIFETIME' => [
+                        'title'      => $this->l('Guest-to-customer token lifetime'),
+                        'hint'       => $this->l('Minutes before a guest-to-customer token expires.'),
+                        'validation' => 'isUnsignedInt',
+                        'cast'       => 'intval',
+                        'size'       => 5,
+                        'type'       => 'text',
+                        'suffix'     => $this->l('minutes'),
+                    ],
+                    'TB_PASSWD_RESET_TOKEN_ON_LOGIN' => [
+                        'title'      => $this->l('Clear reset token on login'),
+                        'hint'       => $this->l('Remove any existing password reset tokens after a successful login.'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                    ],
+                ],
+                'submit' => ['title' => $this->l('Save')],
+            ],
         ];
     }
 

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -352,6 +352,10 @@ class AuthControllerCore extends FrontController
                 // Add customer to the context
                 $this->context->customer = $customer;
 
+                if (Configuration::get('TB_PASSWD_RESET_TOKEN_ON_LOGIN')) {
+                    $customer->clearPasswordResetToken();
+                }
+
                 if (Configuration::get('PS_CART_FOLLOWING') && (empty($this->context->cookie->id_cart) || Cart::getNbProducts($this->context->cookie->id_cart) == 0) && $idCart = (int) Cart::lastNoneOrderedCart($this->context->customer->id)) {
                     $this->context->cart = new Cart($idCart);
                 } else {

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -61,29 +61,20 @@ class PasswordControllerCore extends FrontController
             } else {
                 $customer = new Customer();
                 $customer->getByemail($email);
-                if (!Validate::isLoadedObject($customer)) {
-                    $this->errors[] = Tools::displayError('There is no account registered for this email address.');
-                } elseif (!$customer->active) {
-                    $this->errors[] = Tools::displayError('You cannot regenerate the password for this account.');
-                } elseif ((strtotime($customer->last_passwd_gen.'+'.($minTime = (int) Configuration::get('PS_PASSWD_TIME_FRONT')).' minutes') - time()) > 0) {
-                    $this->errors[] = sprintf(Tools::displayError('You can regenerate your password only every %d minute(s)'), (int) $minTime);
-                } else {
-                    $url = $this->context->link->getPageLink('password', true, null, 'token='.$customer->secure_key.'&id_customer='.(int) $customer->id);
+                $minTime = (int) Configuration::get('PS_PASSWD_TIME_FRONT');
+                if (Validate::isLoadedObject($customer) && $customer->active && (strtotime($customer->last_passwd_gen.'+'.$minTime.' minutes') - time()) <= 0) {
+                    $token = $customer->generatePasswordResetToken();
+                    $url = $this->context->link->getPageLink('password', true, null, 'token='.$token);
                     $mailParams = [
                         '{email}'     => $customer->email,
                         '{lastname}'  => $customer->lastname,
                         '{firstname}' => $customer->firstname,
                         '{url}'       => $url,
                     ];
-                    if (Mail::Send($this->context->language->id, 'password_query', Mail::l('Password query confirmation'), $mailParams, $customer->email, $customer->firstname.' '.$customer->lastname)) {
-                        $this->context->smarty->assign([
-                            'confirmation' => 2,
-                            'customer_email' => $customer->email
-                        ]);
-                    } else {
-                        $this->errors[] = Tools::displayError('An error occurred while sending the email.');
-                    }
+                    Mail::Send($this->context->language->id, 'password_query', Mail::l('Password query confirmation'), $mailParams, $customer->email, $customer->firstname.' '.$customer->lastname);
+                    PrestaShopLogger::addLog(sprintf('Password reset token issued for %s from %s [%s]', $customer->email, Tools::getRemoteAddr(), isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : ''), 1, null, 'Customer', (int) $customer->id, true);
                 }
+                $this->context->smarty->assign(['confirmation' => 2]);
             }
             if ($this->ajax) {
                 $return = [
@@ -124,7 +115,10 @@ class PasswordControllerCore extends FrontController
     {
         parent::initContent();
         if ($customer = $this->getCustomer()) {
-            $this->context->smarty->assign(['customer' => $customer]);
+            $this->context->smarty->assign([
+                'customer' => $customer,
+                'token'    => Tools::getValue('token'),
+            ]);
             $this->setTemplate(_PS_THEME_DIR_.'password-set.tpl');
         } else {
             $this->setTemplate(_PS_THEME_DIR_.'password.tpl');
@@ -143,6 +137,7 @@ class PasswordControllerCore extends FrontController
         $customer->passwd = Tools::hash($password);
         $customer->last_passwd_gen = date('Y-m-d H:i:s', time());
         if ($customer->update()) {
+            $customer->clearPasswordResetToken();
             Hook::triggerEvent('actionPasswordRenew', [
                 'customer' => $customer,
                 'password' => $password
@@ -181,33 +176,32 @@ class PasswordControllerCore extends FrontController
     protected static function resolveCustomer()
     {
         $token = Tools::getValue('token');
-        $idCustomer = Tools::getIntValue('id_customer');
-        if ($token && $idCustomer) {
-            $email = Db::readOnly()->getValue(
+        if ($token) {
+            $row = Db::readOnly()->getRow(
                 (new DbQuery())
-                    ->select('c.`email`')
+                    ->select('c.`id_customer`, c.`reset_password_validity`')
                     ->from('customer', 'c')
-                    ->where('c.`secure_key` = \''.pSQL($token).'\'')
-                    ->where('c.`id_customer` = '.(int) $idCustomer)
+                    ->where('c.`reset_password_token` = \''.pSQL($token).'\'')
             );
-            if ($email) {
-                $customer = new Customer();
-                $customer->getByemail($email);
-                if (!Validate::isLoadedObject($customer)) {
-                    throw new PrestaShopException(Tools::displayError('Customer account not found'));
+            if ($row) {
+                if (strtotime($row['reset_password_validity']) >= time()) {
+                    $customer = new Customer((int) $row['id_customer']);
+                    if (!Validate::isLoadedObject($customer)) {
+                        throw new PrestaShopException(Tools::displayError('Customer account not found'));
+                    }
+                    if (!$customer->active) {
+                        throw new PrestaShopException(Tools::displayError('You cannot regenerate the password for this account.'));
+                    }
+                    return $customer;
                 }
-                if (!$customer->active) {
-                    throw new PrestaShopException(Tools::displayError('You cannot regenerate the password for this account.'));
-                }
-                return $customer;
-            } else {
-                throw new PrestaShopException(Tools::displayError('We cannot regenerate your password with the data you\'ve submitted.'));
+                Db::getInstance()->update('customer', [
+                    'reset_password_token'    => null,
+                    'reset_password_validity' => null,
+                ], 'id_customer='.(int) $row['id_customer']);
             }
-        }
-        if ($token || $idCustomer) {
             throw new PrestaShopException(Tools::displayError('We cannot regenerate your password with the data you\'ve submitted.'));
         }
         return false;
-    }
 
+}
 }

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -140,6 +140,15 @@
     <configuration id="PS_PASSWD_TIME_FRONT" name="PS_PASSWD_TIME_FRONT">
       <value>360</value>
     </configuration>
+    <configuration id="TB_PASSWD_RESET_TOKEN_LIFETIME" name="TB_PASSWD_RESET_TOKEN_LIFETIME">
+      <value>60</value>
+    </configuration>
+    <configuration id="TB_PASSWD_GUEST_TOKEN_LIFETIME" name="TB_PASSWD_GUEST_TOKEN_LIFETIME">
+      <value>2880</value>
+    </configuration>
+    <configuration id="TB_PASSWD_RESET_TOKEN_ON_LOGIN" name="TB_PASSWD_RESET_TOKEN_ON_LOGIN">
+      <value>1</value>
+    </configuration>
     <configuration id="PS_DISP_UNAVAILABLE_ATTR" name="PS_DISP_UNAVAILABLE_ATTR">
       <value>1</value>
     </configuration>

--- a/mails/en/password_query.html
+++ b/mails/en/password_query.html
@@ -89,7 +89,7 @@
 						<span style="color:#777">
 							You have requested to reset your <span style="color:#333"><strong>{shop_name}</strong></span> login details.<br/><br/>
 							Please note that this will change your current password.<br/><br/>
-							To confirm this action, please use the following link: <br /> <a href="{url}" style="color:#337ff1">{url}</a>
+                                                     To confirm this action, please use the following link: <br /> <a href="{url}" style="color:#337ff1">{url}</a><br /><br />This link is valid for one hour and can be used only once.
 						</span>
 					</font>
 				</td>

--- a/mails/en/password_query.txt
+++ b/mails/en/password_query.txt
@@ -11,5 +11,7 @@ To confirm this action, please use the following link:
 
 {url} [{url}]
 
+This link is valid for one hour and can be used only once.
+
 {shop_name} [{shop_url}]
 


### PR DESCRIPTION
## Summary
- use unique CSPRNG tokens for password resets
- allow admins to configure token lifetime and rotation policies
- document one-time reset links in mail templates

## Testing
- `php -l classes/Customer.php`
- `php -l controllers/front/PasswordController.php`
- `php -l controllers/front/AuthController.php`
- `php -l controllers/admin/AdminCustomerPreferencesController.php`


------
https://chatgpt.com/codex/tasks/task_e_68af782498e0832dae297addb545e3a0