### PR TITLE
Fix carrier threshold currency conversion

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -727,14 +727,22 @@ class CarrierCore extends ObjectModel implements InitializationCallback
                 unset($carrierList[$key]);
             }
 
-            if ($carrier->min_total > 0 && ($carrier->min_total > $cart->getOrderTotal($carrier->min_total_tax, Cart::BOTH_WITHOUT_SHIPPING))) {
-                $error[$carrier->id] = static::SHIPPING_PRICE_EXCEPTION;
-                unset($carrierList[$key]);
+            if ($carrier->min_total > 0) {
+                $orderTotal = $cart->getOrderTotal($carrier->min_total_tax, Cart::BOTH_WITHOUT_SHIPPING);
+                $orderTotal = Tools::convertPrice($orderTotal, $cart->id_currency, false);
+                if ($carrier->min_total > $orderTotal) {
+                    $error[$carrier->id] = static::SHIPPING_PRICE_EXCEPTION;
+                    unset($carrierList[$key]);
+                }
             }
 
-            if ($carrier->max_total > 0 && ($carrier->max_total < $cart->getOrderTotal($carrier->max_total_tax, Cart::BOTH_WITHOUT_SHIPPING))) {
-                $error[$carrier->id] = static::SHIPPING_PRICE_EXCEPTION;
-                unset($carrierList[$key]);
+            if ($carrier->max_total > 0) {
+                $orderTotal = $cart->getOrderTotal($carrier->max_total_tax, Cart::BOTH_WITHOUT_SHIPPING);
+                $orderTotal = Tools::convertPrice($orderTotal, $cart->id_currency, false);
+                if ($carrier->max_total < $orderTotal) {
+                    $error[$carrier->id] = static::SHIPPING_PRICE_EXCEPTION;
+                    unset($carrierList[$key]);
+                }
             }
 
             if ($carrier->min_weight > 0 && $cartWeight < $carrier->min_weight) {


### PR DESCRIPTION
## Summary
- ensure carrier min/max order totals use default currency
- convert cart total before comparing to carrier thresholds

## Testing
- `php -l classes/Carrier.php`
- `./vendor/bin/codecept run Unit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c3728d70832d88846870544c233c