### PR TITLE
Allow multiple attachments on customer messages

### DIFF
--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
@@ -128,7 +128,7 @@
 					<div class="row" style="margin-top:10px;">
 						<div class="col-sm-12 form-inline">
 							<label for="file_attachment" class="control-label">{l s='Attach file'}</label>
-							<input type="file" id="file_attachment" name="file_attachment" class="form-control">
+                                                        <input type="file" id="file_attachment" name="file_attachment[]" class="form-control" multiple>
 						</div>
 					</div>
 				</div>

--- a/admin-dev/themes/default/template/controllers/customer_threads/message.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/message.tpl
@@ -39,8 +39,28 @@
 		</dd>
 	</dl>
 
-	<dl class="dl-horizontal">
-		<dt>{l s='Message:'}</dt>
-		<dd>{$message.message|escape:'html':'UTF-8'|nl2br}</dd>
-	</dl>
+        <dl class="dl-horizontal">
+                <dt>{l s='Message:'}</dt>
+                <dd>{$message.message|escape:'html':'UTF-8'|nl2br}</dd>
+        </dl>
+        {if !empty($message.attachments)}
+                <dl class="dl-horizontal">
+                        <dt>{l s='Attached files:'}</dt>
+                        <dd>
+                                <ul class="list-unstyled">
+                                        {foreach from=$message.attachments item=attachment}
+                                                <li>
+                                                        {if $attachment.id_customer_message_attachment}
+                                                                <a href="{$link->getAdminLink('AdminCustomerThreads')|escape:'htmlall':'UTF-8'}&amp;showMessageAttachment={$attachment.id_customer_message_attachment|intval}">
+                                                                        {$attachment.original_name|escape:'htmlall':'UTF-8'}
+                                                                </a>
+                                                        {else}
+                                                                {$attachment.original_name|escape:'htmlall':'UTF-8'}
+                                                        {/if}
+                                                </li>
+                                        {/foreach}
+                                </ul>
+                        </dd>
+                </dl>
+        {/if}
 </div>

--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -836,6 +836,24 @@
                   <p class="message-item-text">
                     {$message['message']|escape:'html':'UTF-8'|nl2br}
                   </p>
+                  {if !empty($message.attachments)}
+                    <div class="message-item-attachments">
+                      <strong>{l s='Attached files:'}</strong>
+                      <ul class="list-unstyled">
+                        {foreach from=$message.attachments item=attachment}
+                          <li>
+                            {if $attachment.id_customer_message_attachment}
+                              <a href="{$link->getAdminLink('AdminCustomerThreads')|escape:'html':'UTF-8'}&amp;showMessageAttachment={$attachment.id_customer_message_attachment|intval}">
+                                {$attachment.original_name|escape:'html':'UTF-8'}
+                              </a>
+                            {else}
+                              {$attachment.original_name|escape:'html':'UTF-8'}
+                            {/if}
+                          </li>
+                        {/foreach}
+                      </ul>
+                    </div>
+                  {/if}
                 </div>
                 {*if ($message['is_new_for_me'])}
                   <a class="new_message" title="{l s='Mark this message as \'viewed\''}" href="{$smarty.server.REQUEST_URI}&amp;token={$smarty.get.token}&amp;messageReaded={$message['id_message']}">
@@ -907,7 +925,7 @@
               <div class="form-group">
                 <label class="control-label col-lg-3">{l s='Attach file'}</label>
                 <div class="col-lg-9">
-                  <input type="file" id="file_attachment" name="file_attachment" class="form-control">
+                  <input type="file" id="file_attachment" name="file_attachment[]" class="form-control" multiple>
                 </div>
               </div>
 

--- a/classes/CustomerMessage.php
+++ b/classes/CustomerMessage.php
@@ -135,7 +135,7 @@ class CustomerMessageCore extends ObjectModel
      */
     public static function getMessagesByOrderId($idOrder, $hidePrivate = true)
     {
-        return Db::readOnly()->getArray(
+        $messages = Db::readOnly()->getArray(
             (new DbQuery())
                 ->select('cm.*')
                 ->select('c.`firstname` AS `cfirstname`')
@@ -152,6 +152,8 @@ class CustomerMessageCore extends ObjectModel
                 ->groupBy('cm.`id_customer_message`')
                 ->orderBy('cm.`date_add` DESC')
         );
+
+        return static::addAttachmentsToMessages($messages);
     }
 
     /**
@@ -190,11 +192,28 @@ class CustomerMessageCore extends ObjectModel
      */
     public function delete()
     {
+        CustomerMessageAttachment::createTable();
+
+        $attachments = CustomerMessageAttachment::getByMessageIds([$this->id]);
+        foreach ($attachments as $messageAttachments) {
+            foreach ($messageAttachments as $attachment) {
+                $filePath = _PS_UPLOAD_DIR_.basename($attachment['file_name']);
+                if (is_file($filePath)) {
+                    unlink($filePath);
+                }
+            }
+        }
+
         if ($this->fileExists()) {
             unlink($this->getFilePath());
         }
 
-        return parent::delete();
+        $result = parent::delete();
+        if ($result) {
+            CustomerMessageAttachment::deleteByMessageId((int)$this->id);
+        }
+
+        return $result;
     }
 
     /**
@@ -219,6 +238,58 @@ class CustomerMessageCore extends ObjectModel
             file_exists($filePath) &&
             is_file($filePath)
         );
+    }
+
+    /**
+     * Attach attachments to the given messages.
+     *
+     * @param array $messages
+     *
+     * @return array
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    public static function addAttachmentsToMessages(array $messages): array
+    {
+        if (!$messages) {
+            return $messages;
+        }
+
+        $ids = [];
+        foreach ($messages as $message) {
+            if (isset($message['id_customer_message'])) {
+                $ids[] = (int)$message['id_customer_message'];
+            }
+        }
+
+        CustomerMessageAttachment::createTable();
+        $attachments = CustomerMessageAttachment::getByMessageIds(array_unique($ids));
+
+        foreach ($messages as &$message) {
+            $messageAttachments = [];
+
+            if (!empty($message['id_customer_message']) && isset($attachments[(int)$message['id_customer_message']])) {
+                foreach ($attachments[(int)$message['id_customer_message']] as $attachment) {
+                    $messageAttachments[] = [
+                        'id_customer_message_attachment' => (int)$attachment['id_customer_message_attachment'],
+                        'file_name'                      => $attachment['file_name'],
+                        'original_name'                  => $attachment['original_name'],
+                    ];
+                }
+            }
+
+            if (!$messageAttachments && !empty($message['file_name'])) {
+                $messageAttachments[] = [
+                    'id_customer_message_attachment' => null,
+                    'file_name'                      => $message['file_name'],
+                    'original_name'                  => basename($message['file_name']),
+                ];
+            }
+
+            $message['attachments'] = $messageAttachments;
+        }
+
+        return $messages;
     }
 
 }

--- a/classes/CustomerMessageAttachment.php
+++ b/classes/CustomerMessageAttachment.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * thirty bees is an extension to the PrestaShop e-commerce software developed by PrestaShop SA
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.thirtybees.com for more information.
+ *
+ * @author    thirty bees <contact@thirtybees.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2017-2024 thirty bees
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
+ */
+
+/**
+ * Class CustomerMessageAttachmentCore
+ */
+class CustomerMessageAttachmentCore extends ObjectModel
+{
+    /** @var int */
+    public $id_customer_message;
+
+    /** @var string */
+    public $file_name;
+
+    /** @var string */
+    public $original_name;
+
+    /** @var string */
+    public $date_add;
+
+    /**
+     * @var array Object model definition
+     */
+    public static $definition = [
+        'table'   => 'customer_message_attachment',
+        'primary' => 'id_customer_message_attachment',
+        'fields'  => [
+            'id_customer_message' => ['type' => self::TYPE_INT, 'dbType' => 'int(11)'],
+            'file_name'           => ['type' => self::TYPE_STRING, 'size' => 255],
+            'original_name'       => ['type' => self::TYPE_STRING, 'size' => 255],
+            'date_add'            => ['type' => self::TYPE_DATE, 'validate' => 'isDate', 'dbNullable' => false],
+        ],
+        'keys'    => [
+            'customer_message_attachment' => [
+                'id_customer_message' => ['type' => ObjectModel::KEY, 'columns' => ['id_customer_message']],
+            ],
+        ],
+    ];
+
+    /**
+     * Ensure the attachment table exists.
+     *
+     * @return void
+     */
+    public static function createTable(): void
+    {
+        $sql = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'customer_message_attachment` (
+            `id_customer_message_attachment` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+            `id_customer_message` INT(11) UNSIGNED NOT NULL,
+            `file_name` VARCHAR(255) NOT NULL,
+            `original_name` VARCHAR(255) NOT NULL,
+            `date_add` DATETIME NOT NULL,
+            PRIMARY KEY (`id_customer_message_attachment`),
+            KEY `id_customer_message` (`id_customer_message`)
+        ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;';
+
+        Db::getInstance()->execute($sql);
+    }
+
+    /**
+     * @param int[] $messageIds
+     *
+     * @return array
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    public static function getByMessageIds(array $messageIds): array
+    {
+        if (!$messageIds) {
+            return [];
+        }
+
+        $ids = array_map('intval', $messageIds);
+
+        $rows = Db::readOnly()->getArray(
+            (new DbQuery())
+                ->select('cma.*')
+                ->from('customer_message_attachment', 'cma')
+                ->where('cma.`id_customer_message` IN ('.implode(',', $ids).')')
+                ->orderBy('cma.`id_customer_message_attachment` ASC')
+        );
+
+        $attachments = [];
+        foreach ($rows as $row) {
+            $attachments[(int)$row['id_customer_message']][] = $row;
+        }
+
+        return $attachments;
+    }
+
+    /**
+     * @param int $messageId
+     *
+     * @return void
+     */
+    public static function deleteByMessageId(int $messageId): void
+    {
+        Db::getInstance()->delete(
+            bqSQL(static::$definition['table']),
+            'id_customer_message = '.(int)$messageId
+        );
+    }
+
+    /**
+     * @param array $fileAttachments
+     * @param array $errors
+     *
+     * @return array
+     */
+    public static function uploadAttachments(array $fileAttachments, array &$errors): array
+    {
+        static::createTable();
+
+        $storedAttachments = [];
+        foreach ($fileAttachments as $fileAttachment) {
+            if (!empty($fileAttachment['rename']) && !empty($fileAttachment['tmp_name'])) {
+                $destination = _PS_UPLOAD_DIR_.basename($fileAttachment['rename']);
+                if (rename($fileAttachment['tmp_name'], $destination)) {
+                    @chmod($destination, 0664);
+                    $storedAttachments[] = [
+                        'file_name'     => basename($fileAttachment['rename']),
+                        'original_name' => $fileAttachment['name'],
+                    ];
+                } else {
+                    $errors[] = Tools::displayError('An error occurred during the file upload process.');
+                }
+            } elseif (!empty($fileAttachment['name']) && ($fileAttachment['error'] != 0)) {
+                $errors[] = Tools::displayError('An error occurred during the file upload process.');
+            }
+        }
+
+        return $storedAttachments;
+    }
+
+    /**
+     * @param int $messageId
+     * @param array $storedAttachments
+     *
+     * @return void
+     */
+    public static function persistAttachments(int $messageId, array $storedAttachments): void
+    {
+        foreach ($storedAttachments as $attachment) {
+            $record = new CustomerMessageAttachment();
+            $record->id_customer_message = $messageId;
+            $record->file_name = $attachment['file_name'];
+            $record->original_name = $attachment['original_name'];
+            $record->add();
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilePath(): string
+    {
+        return _PS_UPLOAD_DIR_.basename($this->file_name);
+    }
+}

--- a/classes/CustomerThread.php
+++ b/classes/CustomerThread.php
@@ -138,7 +138,9 @@ class CustomerThreadCore extends ObjectModel
             $sql->where('ct.`id_order` = '.(int) $idOrder);
         }
 
-        return Db::readOnly()->getArray($sql);
+        $messages = Db::readOnly()->getArray($sql);
+
+        return CustomerMessage::addAttachmentsToMessages($messages);
     }
 
     /**
@@ -208,7 +210,7 @@ class CustomerThreadCore extends ObjectModel
      */
     public static function getMessageCustomerThreads($idCustomerThread)
     {
-        return Db::readOnly()->getArray(
+        $messages = Db::readOnly()->getArray(
             (new DbQuery())
                 ->select('ct.*, cm.*, cl.name subject, CONCAT(e.firstname, \' \', e.lastname) employee_name')
                 ->select('CONCAT(c.firstname, \' \', c.lastname) customer_name, c.firstname')
@@ -220,6 +222,8 @@ class CustomerThreadCore extends ObjectModel
                 ->where('ct.`id_customer_thread` = '.(int) $idCustomerThread)
                 ->orderBy('cm.`date_add` ASC')
         );
+
+        return CustomerMessage::addAttachmentsToMessages($messages);
     }
 
     /**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -4270,6 +4270,67 @@ FileETag none
     }
 
     /**
+     * Returns an array containing information about
+     * HTTP file upload variable ( $_FILES )
+     *
+     * @param string $input File upload field name
+     * @param bool $returnContent If true, returns uploaded file contents
+     *
+     * @return array
+     */
+    public static function fileAttachments(string $input = 'fileUpload', bool $returnContent = true): array
+    {
+        if (empty($_FILES[$input])) {
+            return [];
+        }
+
+        $files = $_FILES[$input];
+
+        $names = (array) ($files['name'] ?? []);
+        $tmpNames = (array) ($files['tmp_name'] ?? []);
+        $types = (array) ($files['type'] ?? []);
+        $errors = (array) ($files['error'] ?? []);
+        $sizes = (array) ($files['size'] ?? []);
+
+        // Normalize single file uploads into arrays
+        $count = max(count($names), count($tmpNames), count($types), count($errors), count($sizes));
+        if ($count === 0 && isset($files['name'])) {
+            $names = [$files['name']];
+            $tmpNames = [$files['tmp_name'] ?? ''];
+            $types = [$files['type'] ?? ''];
+            $errors = [$files['error'] ?? 0];
+            $sizes = [$files['size'] ?? 0];
+            $count = 1;
+        }
+
+        $attachments = [];
+        for ($i = 0; $i < $count; $i++) {
+            $name = $names[$i] ?? '';
+            if ($name === '') {
+                continue;
+            }
+
+            $tmpName = $tmpNames[$i] ?? '';
+            $attachment = [
+                'rename'   => $tmpName ? uniqid().mb_strtolower(substr($name, -5)) : null,
+                'tmp_name' => $tmpName,
+                'name'     => $name,
+                'mime'     => $types[$i] ?? '',
+                'error'    => $errors[$i] ?? 0,
+                'size'     => $sizes[$i] ?? 0,
+            ];
+
+            if ($returnContent && $tmpName) {
+                $attachment['content'] = file_get_contents($tmpName);
+            }
+
+            $attachments[] = $attachment;
+        }
+
+        return $attachments;
+    }
+
+    /**
      * @param string $filename
      *
      * @return bool

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -598,16 +598,17 @@ class AdminCustomerThreadsControllerCore extends AdminController
                 $cm->id_customer_thread = $ct->id;
                 $cm->ip_address = (int) ip2long(Tools::getRemoteAddr());
                 $cm->message = Tools::getValue('reply_message');
-                $fileAttachment = Tools::fileAttachment('file_attachment');
-                if (!empty($fileAttachment['rename']) && rename($fileAttachment['tmp_name'], _PS_UPLOAD_DIR_.basename($fileAttachment['rename']))) {
-                    $cm->file_name = $fileAttachment['rename'];
-                    @chmod(_PS_UPLOAD_DIR_.basename($fileAttachment['rename']), 0664);
+                $fileAttachments = Tools::fileAttachments('file_attachment');
+                $storedAttachments = CustomerMessageAttachment::uploadAttachments($fileAttachments, $this->errors);
+
+                if (!$this->errors && $storedAttachments) {
+                    $cm->file_name = $storedAttachments[0]['file_name'];
                 }
+
                 if (($error = $cm->validateField('message', $cm->message, null, [], true)) !== true) {
                     $this->errors[] = $error;
-                } elseif (!empty($fileAttachment['name']) && $fileAttachment['error'] != 0) {
-                    $this->errors[] = Tools::displayError('An error occurred during the file upload process.');
-                } elseif ($cm->add()) {
+                } elseif (empty($this->errors) && $cm->add()) {
+                    CustomerMessageAttachment::persistAttachments((int)$cm->id, $storedAttachments);
                     $customer = new Customer($ct->id_customer);
                     $params = [
                         '{reply}'     => Tools::nl2br(Tools::getValue('reply_message')),
@@ -638,7 +639,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         null,
                         Tools::convertEmailToIdn($fromEmail),
                         $fromName,
-                        $fileAttachment,
+                        $fileAttachments,
                         null,
                         _PS_MAIL_DIR_,
                         true,
@@ -1109,20 +1110,28 @@ class AdminCustomerThreadsControllerCore extends AdminController
             ob_end_clean();
         }
 
-        $customerMessage = new CustomerMessage($customerMessageId);
-        if (! Validate::isLoadedObject($customerMessage)) {
-            die('Customer message not found');
+        $attachment = new CustomerMessageAttachment($customerMessageId);
+        if (Validate::isLoadedObject($attachment) && $attachment->id) {
+            $filepath = $attachment->getFilePath();
+            $filename = $attachment->original_name;
+        } else {
+            $customerMessage = new CustomerMessage($customerMessageId);
+            if (! Validate::isLoadedObject($customerMessage)) {
+                die('Customer message not found');
+            }
+
+            if (! $customerMessage->file_name) {
+                die('This customer message do not have file attachement');
+            }
+
+            if (! $customerMessage->fileExists()) {
+                die('File not found');
+            }
+
+            $filepath = $customerMessage->getFilePath();
+            $filename = basename($customerMessage->file_name);
         }
 
-        if (! $customerMessage->file_name) {
-            die('This customer message do not have file attachement');
-        }
-
-        if (! $customerMessage->fileExists()) {
-            die('File not found');
-        }
-
-        $filename = basename($customerMessage->file_name);
         $contentType = 'application/octet-stream';
 
         // Todo: Once getFileInformations() is also defined for other types than image, the $extensions array can be emptied
@@ -1154,7 +1163,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
 
         header('Content-Type: '.$contentType);
         header('Content-Disposition:attachment;filename="'.$filename.'"');
-        readfile($customerMessage->getFilePath());
+        readfile($filepath);
         die;
     }
 

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -751,19 +751,21 @@ class AdminOrdersControllerCore extends AdminController
                         $customerMessage->id_employee = (int) $this->context->employee->id;
                         $customerMessage->message = Tools::getValue('message');
                         $customerMessage->private = Tools::getValue('visibility');
-                        $fileAttachment = Tools::fileAttachment('file_attachment');
-                        if (!empty($fileAttachment['rename']) && rename($fileAttachment['tmp_name'], _PS_UPLOAD_DIR_.basename($fileAttachment['rename']))) {
-                            $customerMessage->file_name = $fileAttachment['rename'];
-                            @chmod(_PS_UPLOAD_DIR_.basename($fileAttachment['rename']), 0664);
+                        $fileAttachments = Tools::fileAttachments('file_attachment');
+                        $storedAttachments = CustomerMessageAttachment::uploadAttachments($fileAttachments, $this->errors);
+
+                        if (!$this->errors && $storedAttachments) {
+                            $customerMessage->file_name = $storedAttachments[0]['file_name'];
                         }
-                        if (!empty($fileAttachment['name']) && $fileAttachment['error'] != 0) {
-                            $this->errors[] = Tools::displayError('An error occurred during the file upload process.');
-                        }
-                        if (!$customerMessage->add()) {
+                        if (!$this->errors && !$customerMessage->add()) {
                             $this->errors[] = Tools::displayError('An error occurred while saving the message.');
-                        } elseif ($customerMessage->private) {
-                            Tools::redirectAdmin(static::$currentIndex.'&id_order='.(int) $order->id.'&vieworder&conf=11&token='.$this->token);
-                        } else {
+                        } elseif (!$this->errors) {
+                            CustomerMessageAttachment::persistAttachments((int)$customerMessage->id, $storedAttachments);
+
+                            if ($customerMessage->private) {
+                                Tools::redirectAdmin(static::$currentIndex.'&id_order='.(int) $order->id.'&vieworder&conf=11&token='.$this->token);
+                            }
+
                             $message = $customerMessage->message;
                             if (Configuration::get('PS_MAIL_TYPE', null, null, $order->id_shop) != Mail::TYPE_TEXT) {
                                 $message = Tools::nl2br($customerMessage->message);
@@ -784,7 +786,7 @@ class AdminOrdersControllerCore extends AdminController
                                 $customer->firstname.' '.$customer->lastname,
                                 null,
                                 null,
-                                $fileAttachment,
+                                $fileAttachments,
                                 null,
                                 _PS_MAIL_DIR_,
                                 true,

--- a/controllers/front/ContactController.php
+++ b/controllers/front/ContactController.php
@@ -64,7 +64,7 @@ class ContactControllerCore extends FrontController
                 }
             }
 
-            $fileAttachment = Tools::fileAttachment('fileUpload');
+            $fileAttachments = Tools::fileAttachments('fileUpload');
             $message = (string)Tools::getValue('message');
             if (!($from = Tools::convertEmailToIdn(trim(Tools::getValue('from')))) || !Validate::isEmail($from)) {
                 $this->errors[] = Tools::displayError('Invalid email address.');
@@ -74,11 +74,22 @@ class ContactControllerCore extends FrontController
                 $this->errors[] = Tools::displayError('Invalid message');
             } elseif (!($idContact = Tools::getIntValue('id_contact')) || !(Validate::isLoadedObject($contact = new Contact($idContact, $this->context->language->id)))) {
                 $this->errors[] = Tools::displayError('Please select a subject from the list provided. ');
-            } elseif (!empty($fileAttachment['name']) && $fileAttachment['error'] != 0) {
-                $this->errors[] = Tools::displayError('An error occurred during the file-upload process.');
-            } elseif (!empty($fileAttachment['name']) && !in_array(mb_strtolower(substr($fileAttachment['name'], -4)), $extension) && !in_array(mb_strtolower(substr($fileAttachment['name'], -5)), $extension)) {
-                $this->errors[] = Tools::displayError('Bad file extension');
             } else {
+                foreach ($fileAttachments as $fileAttachment) {
+                    if (!empty($fileAttachment['name']) && $fileAttachment['error'] != 0) {
+                        $this->errors[] = Tools::displayError('An error occurred during the file-upload process.');
+                        break;
+                    }
+                    if (!empty($fileAttachment['name']) && !in_array(mb_strtolower(substr($fileAttachment['name'], -4)), $extension) && !in_array(mb_strtolower(substr($fileAttachment['name'], -5)), $extension)) {
+                        $this->errors[] = Tools::displayError('Bad file extension');
+                        break;
+                    }
+                }
+
+                if ($this->errors) {
+                    return;
+                }
+
                 $customer = $this->context->customer;
                 if (!$customer->id) {
                     $customer->getByEmail($from);
@@ -142,17 +153,19 @@ class ContactControllerCore extends FrontController
                             $cm = new CustomerMessage();
                             $cm->id_customer_thread = $ct->id;
                             $cm->message = $message;
-                            if (!empty($fileAttachment['rename'])) {
-                                $cm->file_name = basename($fileAttachment['rename']);
-                                if (! rename($fileAttachment['tmp_name'], $cm->getFilePath())) {
-                                    $cm->file_name = null;
-                                }
+
+                            $storedAttachments = CustomerMessageAttachment::uploadAttachments($fileAttachments, $this->errors);
+                            if ($storedAttachments) {
+                                $cm->file_name = $storedAttachments[0]['file_name'];
                             }
+
                             $cm->ip_address = (int)ip2long(Tools::getRemoteAddr());
                             $length = ObjectModel::getDefinition('CustomerMessage', 'user_agent')['size'];
                             $cm->user_agent = substr($_SERVER['HTTP_USER_AGENT'], 0, $length);
-                            if (!$cm->add()) {
+                            if (!$this->errors && !$cm->add()) {
                                 $this->errors[] = Tools::displayError('An error occurred while sending the message.');
+                            } elseif (!$this->errors) {
+                                CustomerMessageAttachment::persistAttachments((int)$cm->id, $storedAttachments);
                             }
                         } else {
                             $this->errors[] = Tools::displayError('An error occurred while sending the message.');
@@ -160,7 +173,17 @@ class ContactControllerCore extends FrontController
                     }
 
                     if (! $this->errors) {
-                        $this->sendEmails($message, $from, $fileAttachment, $ct, $contact);
+                        $sentAttachments = [];
+                        foreach ($fileAttachments as $fileAttachment) {
+                            foreach ($storedAttachments as $storedAttachment) {
+                                if (!empty($fileAttachment['rename']) && basename($fileAttachment['rename']) === $storedAttachment['file_name']) {
+                                    $sentAttachments[] = $fileAttachment;
+                                    break;
+                                }
+                            }
+                        }
+
+                        $this->sendEmails($message, $from, $sentAttachments, $ct, $contact);
                     }
                 }
 
@@ -322,13 +345,13 @@ class ContactControllerCore extends FrontController
      *
      * @param array $varList
      * @param Contact $contact
-     * @param array|null $fileAttachment
+     * @param array $fileAttachments
      * @param string $from
      *
      * @return bool
      * @throws PrestaShopException
      */
-    protected function sendNotificationEmail(array $varList, Contact $contact, ?array $fileAttachment, string $from): bool
+    protected function sendNotificationEmail(array $varList, Contact $contact, array $fileAttachments, string $from): bool
     {
         return Mail::Send(
             $this->context->language->id,
@@ -339,7 +362,7 @@ class ContactControllerCore extends FrontController
             $contact->name,
             null,
             null,
-            $fileAttachment,
+            $fileAttachments,
             null,
             _PS_MAIL_DIR_,
             false,
@@ -355,13 +378,13 @@ class ContactControllerCore extends FrontController
      * @param CustomerThread|null $ct
      * @param array $varList
      * @param string $to
-     * @param array|null $fileAttachment
+     * @param array $fileAttachments
      * @param Contact $contact
      *
      * @return bool
      * @throws PrestaShopException
      */
-    protected function sendConfirmationEmail(?CustomerThread $ct, array $varList, string $to, ?array $fileAttachment, Contact $contact): bool
+    protected function sendConfirmationEmail(?CustomerThread $ct, array $varList, string $to, array $fileAttachments, Contact $contact): bool
     {
         if ($contact->send_confirm) {
             if (Validate::isLoadedObject($ct)) {
@@ -374,7 +397,7 @@ class ContactControllerCore extends FrontController
                     null,
                     null,
                     null,
-                    $fileAttachment,
+                    $fileAttachments,
                     null,
                     _PS_MAIL_DIR_,
                     false,
@@ -392,7 +415,7 @@ class ContactControllerCore extends FrontController
                     null,
                     null,
                     null,
-                    $fileAttachment,
+                    $fileAttachments,
                     null,
                     _PS_MAIL_DIR_,
                     false,
@@ -410,14 +433,14 @@ class ContactControllerCore extends FrontController
      *
      * @param string $message
      * @param string $from
-     * @param array|null $fileAttachment
+     * @param array $fileAttachments
      * @param CustomerThread|null $ct
      * @param Contact $contact
      *
      * @return void
      * @throws PrestaShopException
      */
-    protected function sendEmails($message, string $from, ?array $fileAttachment, ?CustomerThread $ct, Contact $contact): void
+    protected function sendEmails($message, string $from, array $fileAttachments, ?CustomerThread $ct, Contact $contact): void
     {
         $varList = [
             '{order_name}' => '-',
@@ -427,8 +450,16 @@ class ContactControllerCore extends FrontController
             '{product_name}' => '',
         ];
 
-        if (isset($fileAttachment['name'])) {
-            $varList['{attached_file}'] = $fileAttachment['name'];
+        if (!empty($fileAttachments)) {
+            $names = [];
+            foreach ($fileAttachments as $fileAttachment) {
+                if (isset($fileAttachment['name'])) {
+                    $names[] = $fileAttachment['name'];
+                }
+            }
+            if ($names) {
+                $varList['{attached_file}'] = implode(', ', $names);
+            }
         }
 
         if (Validate::isLoadedObject($ct) && $ct->id_order) {
@@ -445,11 +476,11 @@ class ContactControllerCore extends FrontController
             }
         }
 
-        if (!$this->sendNotificationEmail($varList, $contact, $fileAttachment, $from)) {
+        if (!$this->sendNotificationEmail($varList, $contact, $fileAttachments, $from)) {
             $this->errors[] = Tools::displayError('An error occurred while sending the message.');
         }
 
-        if (!$this->sendConfirmationEmail($ct, $varList, $from, $fileAttachment, $contact)) {
+        if (!$this->sendConfirmationEmail($ct, $varList, $from, $fileAttachments, $contact)) {
             $this->errors[] = Tools::displayError('An error occurred while sending the message.');
         }
     }


### PR DESCRIPTION
## Summary
- add a dedicated customer message attachment model/table and wire it into message retrieval
- allow customer service and order messaging forms to upload multiple attachments and preserve them when emailing
- render attached files under each message with download links in the admin views

## Testing
- php -l classes/Tools.php
- php -l controllers/front/ContactController.php
- php -l controllers/admin/AdminCustomerThreadsController.php
- php -l controllers/admin/AdminOrdersController.php
- php -l classes/CustomerMessageAttachment.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343a5428f0832d927685fd7949248c)