### PR TITLE
Support multiple attachments on customer messages

### DIFF
--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
@@ -128,7 +128,7 @@
 					<div class="row" style="margin-top:10px;">
 						<div class="col-sm-12 form-inline">
 							<label for="file_attachment" class="control-label">{l s='Attach file'}</label>
-							<input type="file" id="file_attachment" name="file_attachment" class="form-control">
+                                                        <input type="file" id="file_attachment" name="file_attachment[]" class="form-control" multiple>
 						</div>
 					</div>
 				</div>

--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -836,6 +836,24 @@
                   <p class="message-item-text">
                     {$message['message']|escape:'html':'UTF-8'|nl2br}
                   </p>
+                  {if isset($message.attachments) && $message.attachments|@count}
+                    <div class="message-item-attachments">
+                      <strong>{l s='Attached files:'}</strong>
+                      <ul class="list-unstyled">
+                        {foreach from=$message.attachments item=attachment}
+                          <li>
+                            {if $attachment.id_customer_message_attachment}
+                              <a href="{$link->getAdminLink('AdminCustomerThreads')|escape:'html':'UTF-8'}&downloadCustomerMessageAttachment={$attachment.id_customer_message_attachment|intval}">
+                                {$attachment.original_name|escape:'html':'UTF-8'}
+                              </a>
+                            {else}
+                              {$attachment.original_name|escape:'html':'UTF-8'}
+                            {/if}
+                          </li>
+                        {/foreach}
+                      </ul>
+                    </div>
+                  {/if}
                 </div>
                 {*if ($message['is_new_for_me'])}
                   <a class="new_message" title="{l s='Mark this message as \'viewed\''}" href="{$smarty.server.REQUEST_URI}&amp;token={$smarty.get.token}&amp;messageReaded={$message['id_message']}">
@@ -907,7 +925,7 @@
               <div class="form-group">
                 <label class="control-label col-lg-3">{l s='Attach file'}</label>
                 <div class="col-lg-9">
-                  <input type="file" id="file_attachment" name="file_attachment" class="form-control">
+                  <input type="file" id="file_attachment" name="file_attachment[]" class="form-control" multiple>
                 </div>
               </div>
 

--- a/classes/CustomerMessage.php
+++ b/classes/CustomerMessage.php
@@ -194,6 +194,13 @@ class CustomerMessageCore extends ObjectModel
             unlink($this->getFilePath());
         }
 
+        foreach (CustomerMessageAttachment::getByCustomerMessageId((int) $this->id) as $attachment) {
+            if ($attachment->fileExists()) {
+                unlink($attachment->getFilePath());
+            }
+            $attachment->delete();
+        }
+
         return parent::delete();
     }
 
@@ -219,6 +226,21 @@ class CustomerMessageCore extends ObjectModel
             file_exists($filePath) &&
             is_file($filePath)
         );
+    }
+
+    /**
+     * @return CustomerMessageAttachment[]
+     * @throws PrestaShopException
+     */
+    public function getAttachments(): array
+    {
+        $attachments = CustomerMessageAttachment::getByCustomerMessageId((int) $this->id);
+
+        if ($this->file_name) {
+            $attachments[] = CustomerMessageAttachment::fromLegacy($this->file_name);
+        }
+
+        return $attachments;
     }
 
 }

--- a/classes/CustomerMessageAttachment.php
+++ b/classes/CustomerMessageAttachment.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * thirty bees is an extension to the PrestaShop e-commerce software developed by PrestaShop SA
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.thirtybees.com for more information.
+ *
+ * @author    thirty bees <contact@thirtybees.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2017-2024 thirty bees
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
+ */
+
+/**
+ * Class CustomerMessageAttachmentCore
+ */
+class CustomerMessageAttachmentCore extends ObjectModel
+{
+    /** @var int $id_customer_message */
+    public $id_customer_message;
+
+    /** @var string $file_name */
+    public $file_name;
+
+    /** @var string $original_name */
+    public $original_name;
+
+    /** @var string|null $mime */
+    public $mime;
+
+    /** @var bool */
+    protected static $tableChecked = false;
+
+    /** @var array Object model definition */
+    public static $definition = [
+        'table'   => 'customer_message_attachment',
+        'primary' => 'id_customer_message_attachment',
+        'fields'  => [
+            'id_customer_message' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
+            'file_name'           => ['type' => self::TYPE_STRING, 'size' => 64, 'required' => true],
+            'original_name'       => ['type' => self::TYPE_STRING, 'size' => 255, 'required' => true],
+            'mime'                => ['type' => self::TYPE_STRING, 'size' => 255],
+        ],
+        'keys' => [
+            'customer_message_attachment' => [
+                'id_customer_message' => ['type' => ObjectModel::KEY, 'columns' => ['id_customer_message']],
+            ],
+        ],
+    ];
+
+    /**
+     * Ensure the database table exists before using it.
+     *
+     * @return void
+     *
+     * @throws PrestaShopException
+     */
+    public static function ensureTableExists(): void
+    {
+        if (static::$tableChecked) {
+            return;
+        }
+
+        $createSql = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.bqSQL(static::$definition['table']).'` (
+            `'.bqSQL(static::$definition['primary']).'` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+            `id_customer_message` INT(11) UNSIGNED NOT NULL,
+            `file_name` VARCHAR(64) NOT NULL,
+            `original_name` VARCHAR(255) NOT NULL,
+            `mime` VARCHAR(255) DEFAULT NULL,
+            PRIMARY KEY (`'.bqSQL(static::$definition['primary']).'`),
+            KEY `id_customer_message` (`id_customer_message`)
+        ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8';
+
+        Db::getInstance()->execute($createSql);
+        static::$tableChecked = true;
+    }
+
+    /**
+     * @param int $customerMessageId
+     *
+     * @return static[]
+     *
+     * @throws PrestaShopException
+     */
+    public static function getByCustomerMessageId(int $customerMessageId): array
+    {
+        static::ensureTableExists();
+
+        $rows = Db::readOnly()->getArray(
+            (new DbQuery())
+                ->select('*')
+                ->from(static::$definition['table'])
+                ->where('`id_customer_message` = '.(int) $customerMessageId)
+        );
+
+        $attachments = [];
+        foreach ($rows as $row) {
+            $attachment = new static();
+            $attachment->hydrate($row);
+            $attachments[] = $attachment;
+        }
+
+        return $attachments;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilePath(): string
+    {
+        return _PS_UPLOAD_DIR_.basename($this->file_name);
+    }
+
+    /**
+     * @return bool
+     */
+    public function fileExists(): bool
+    {
+        $path = $this->getFilePath();
+
+        return $path && file_exists($path) && is_file($path);
+    }
+
+    /**
+     * @param string $legacyFileName
+     *
+     * @return static
+     */
+    public static function fromLegacy(string $legacyFileName): self
+    {
+        $attachment = new static();
+        $attachment->id_customer_message = 0;
+        $attachment->file_name = $legacyFileName;
+        $attachment->original_name = basename($legacyFileName);
+        $attachment->mime = null;
+
+        return $attachment;
+    }
+}
+

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -4270,6 +4270,61 @@ FileETag none
     }
 
     /**
+     * Returns a normalized array of uploaded files.
+     *
+     * @param string $input
+     * @param bool $returnContent
+     *
+     * @return array
+     */
+    public static function fileAttachments(string $input = 'fileUpload', bool $returnContent = true): array
+    {
+        $attachments = [];
+
+        if (empty($_FILES[$input])) {
+            return $attachments;
+        }
+
+        $names = $_FILES[$input]['name'];
+        $tmpNames = $_FILES[$input]['tmp_name'];
+        $errors = $_FILES[$input]['error'];
+        $types = $_FILES[$input]['type'];
+        $sizes = $_FILES[$input]['size'];
+
+        if (!is_array($names)) {
+            $single = static::fileAttachment($input, $returnContent);
+            if ($single) {
+                $attachments[] = $single;
+            }
+
+            return $attachments;
+        }
+
+        foreach ($names as $index => $name) {
+            if (empty($name) || empty($tmpNames[$index])) {
+                continue;
+            }
+
+            $attachment = [
+                'rename'   => uniqid().mb_strtolower(substr($name, -5)),
+                'tmp_name' => $tmpNames[$index],
+                'name'     => $name,
+                'mime'     => $types[$index],
+                'error'    => $errors[$index],
+                'size'     => $sizes[$index],
+            ];
+
+            if ($returnContent) {
+                $attachment['content'] = file_get_contents($tmpNames[$index]);
+            }
+
+            $attachments[] = $attachment;
+        }
+
+        return $attachments;
+    }
+
+    /**
      * @param string $filename
      *
      * @return bool

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -598,16 +598,48 @@ class AdminCustomerThreadsControllerCore extends AdminController
                 $cm->id_customer_thread = $ct->id;
                 $cm->ip_address = (int) ip2long(Tools::getRemoteAddr());
                 $cm->message = Tools::getValue('reply_message');
-                $fileAttachment = Tools::fileAttachment('file_attachment');
-                if (!empty($fileAttachment['rename']) && rename($fileAttachment['tmp_name'], _PS_UPLOAD_DIR_.basename($fileAttachment['rename']))) {
-                    $cm->file_name = $fileAttachment['rename'];
-                    @chmod(_PS_UPLOAD_DIR_.basename($fileAttachment['rename']), 0664);
+                $fileAttachments = Tools::fileAttachments('file_attachment');
+                foreach ($fileAttachments as $index => $attachment) {
+                    if (!empty($attachment['rename']) && rename($attachment['tmp_name'], _PS_UPLOAD_DIR_.basename($attachment['rename']))) {
+                        $fileAttachments[$index]['stored_name'] = $attachment['rename'];
+                        if ($index === 0) {
+                            $cm->file_name = $attachment['rename'];
+                        }
+                        @chmod(_PS_UPLOAD_DIR_.basename($attachment['rename']), 0664);
+                    }
                 }
                 if (($error = $cm->validateField('message', $cm->message, null, [], true)) !== true) {
                     $this->errors[] = $error;
-                } elseif (!empty($fileAttachment['name']) && $fileAttachment['error'] != 0) {
+                } elseif (array_reduce($fileAttachments, function ($carry, $attachment) {
+                    return $carry || (!empty($attachment['name']) && $attachment['error'] != 0);
+                }, false)) {
                     $this->errors[] = Tools::displayError('An error occurred during the file upload process.');
                 } elseif ($cm->add()) {
+                    $mailAttachments = [];
+
+                    if ($fileAttachments) {
+                        CustomerMessageAttachment::ensureTableExists();
+                    }
+
+                    foreach ($fileAttachments as $attachment) {
+                        if (empty($attachment['stored_name'])) {
+                            continue;
+                        }
+
+                        $record = new CustomerMessageAttachment();
+                        $record->id_customer_message = (int) $cm->id;
+                        $record->file_name = $attachment['stored_name'];
+                        $record->original_name = $attachment['name'];
+                        $record->mime = $attachment['mime'];
+                        $record->add();
+
+                        $mailAttachments[] = [
+                            'content' => file_get_contents(_PS_UPLOAD_DIR_.basename($attachment['stored_name'])),
+                            'name'    => $attachment['name'],
+                            'mime'    => $attachment['mime'],
+                        ];
+                    }
+
                     $customer = new Customer($ct->id_customer);
                     $params = [
                         '{reply}'     => Tools::nl2br(Tools::getValue('reply_message')),
@@ -638,7 +670,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         null,
                         Tools::convertEmailToIdn($fromEmail),
                         $fromName,
-                        $fileAttachment,
+                        $mailAttachments,
                         null,
                         _PS_MAIL_DIR_,
                         true,
@@ -757,6 +789,10 @@ class AdminCustomerThreadsControllerCore extends AdminController
      */
     public function initContent()
     {
+        if ($attachmentId = Tools::getIntValue('downloadCustomerMessageAttachment')) {
+            static::openAttachmentById($attachmentId);
+        }
+
         if ($messageId = Tools::getIntValue('showMessageAttachment')) {
             static::openUploadedFile($messageId);
         }
@@ -1156,6 +1192,35 @@ class AdminCustomerThreadsControllerCore extends AdminController
         header('Content-Disposition:attachment;filename="'.$filename.'"');
         readfile($customerMessage->getFilePath());
         die;
+    }
+
+    /**
+     * @param int $attachmentId
+     *
+     * @return void
+     *
+     * @throws PrestaShopException
+     */
+    protected function openAttachmentById(int $attachmentId)
+    {
+        CustomerMessageAttachment::ensureTableExists();
+
+        $attachment = new CustomerMessageAttachment($attachmentId);
+        if (!Validate::isLoadedObject($attachment)) {
+            die('Customer message attachment not found');
+        }
+
+        if (!$attachment->fileExists()) {
+            die('File not found');
+        }
+
+        $filename = basename($attachment->file_name);
+        $contentType = $attachment->mime ?: 'application/octet-stream';
+
+        header('Content-Type: '.$contentType);
+        header('Content-Disposition: attachment; filename="'.mb_convert_encoding($attachment->original_name, 'ISO-8859-1', 'UTF-8').'"');
+        readfile($attachment->getFilePath());
+        exit;
     }
 
     /**

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -751,19 +751,45 @@ class AdminOrdersControllerCore extends AdminController
                         $customerMessage->id_employee = (int) $this->context->employee->id;
                         $customerMessage->message = Tools::getValue('message');
                         $customerMessage->private = Tools::getValue('visibility');
-                        $fileAttachment = Tools::fileAttachment('file_attachment');
-                        if (!empty($fileAttachment['rename']) && rename($fileAttachment['tmp_name'], _PS_UPLOAD_DIR_.basename($fileAttachment['rename']))) {
-                            $customerMessage->file_name = $fileAttachment['rename'];
-                            @chmod(_PS_UPLOAD_DIR_.basename($fileAttachment['rename']), 0664);
+                        $fileAttachments = Tools::fileAttachments('file_attachment');
+                        foreach ($fileAttachments as $index => $attachment) {
+                            if (!empty($attachment['rename']) && rename($attachment['tmp_name'], _PS_UPLOAD_DIR_.basename($attachment['rename']))) {
+                                $fileAttachments[$index]['stored_name'] = $attachment['rename'];
+                                if ($index === 0) {
+                                    $customerMessage->file_name = $attachment['rename'];
+                                }
+                                @chmod(_PS_UPLOAD_DIR_.basename($attachment['rename']), 0664);
+                            }
                         }
-                        if (!empty($fileAttachment['name']) && $fileAttachment['error'] != 0) {
+                        if (array_reduce($fileAttachments, function ($carry, $attachment) {
+                            return $carry || (!empty($attachment['name']) && $attachment['error'] != 0);
+                        }, false)) {
                             $this->errors[] = Tools::displayError('An error occurred during the file upload process.');
                         }
                         if (!$customerMessage->add()) {
                             $this->errors[] = Tools::displayError('An error occurred while saving the message.');
-                        } elseif ($customerMessage->private) {
-                            Tools::redirectAdmin(static::$currentIndex.'&id_order='.(int) $order->id.'&vieworder&conf=11&token='.$this->token);
                         } else {
+                            if ($fileAttachments) {
+                                CustomerMessageAttachment::ensureTableExists();
+                            }
+
+                            foreach ($fileAttachments as $attachment) {
+                                if (empty($attachment['stored_name'])) {
+                                    continue;
+                                }
+
+                                $record = new CustomerMessageAttachment();
+                                $record->id_customer_message = (int) $customerMessage->id;
+                                $record->file_name = $attachment['stored_name'];
+                                $record->original_name = $attachment['name'];
+                                $record->mime = $attachment['mime'];
+                                $record->add();
+                            }
+
+                            if ($customerMessage->private) {
+                                Tools::redirectAdmin(static::$currentIndex.'&id_order='.(int) $order->id.'&vieworder&conf=11&token='.$this->token);
+                            }
+
                             $message = $customerMessage->message;
                             if (Configuration::get('PS_MAIL_TYPE', null, null, $order->id_shop) != Mail::TYPE_TEXT) {
                                 $message = Tools::nl2br($customerMessage->message);
@@ -784,7 +810,15 @@ class AdminOrdersControllerCore extends AdminController
                                 $customer->firstname.' '.$customer->lastname,
                                 null,
                                 null,
-                                $fileAttachment,
+                                array_map(function ($attachment) {
+                                    return [
+                                        'content' => file_get_contents(_PS_UPLOAD_DIR_.basename($attachment['stored_name'])),
+                                        'name'    => $attachment['name'],
+                                        'mime'    => $attachment['mime'],
+                                    ];
+                                }, array_filter($fileAttachments, function ($attachment) {
+                                    return !empty($attachment['stored_name']);
+                                })),
                                 null,
                                 _PS_MAIL_DIR_,
                                 true,
@@ -1980,6 +2014,21 @@ class AdminOrdersControllerCore extends AdminController
             $orderState['text-color'] = Tools::getBrightness($orderState['color']) < 128 ? 'white' : 'black';
         }
 
+        $messages = CustomerMessage::getMessagesByOrderId($order->id, false);
+        foreach ($messages as &$message) {
+            $messageAttachments = [];
+            $customerMessage = new CustomerMessage((int) $message['id_customer_message']);
+            foreach ($customerMessage->getAttachments() as $attachment) {
+                $messageAttachments[] = [
+                    'id_customer_message_attachment' => (int) $attachment->id,
+                    'file_name'                      => $attachment->file_name,
+                    'original_name'                  => $attachment->original_name,
+                ];
+            }
+            $message['attachments'] = $messageAttachments;
+        }
+        unset($message);
+
         // Smarty assign
         $this->tpl_view_vars = [
             'order'                        => $order,
@@ -2002,7 +2051,7 @@ class AdminOrdersControllerCore extends AdminController
             'customer_thread_message'      => CustomerThread::getCustomerMessages($order->id_customer, null, $order->id),
             'orderMessages'                => OrderMessage::getOrderMessages($order->id_lang, $order, $customer),
             'orderDocuments'               => $order->getDocuments(),
-            'messages'                     => CustomerMessage::getMessagesByOrderId($order->id, false),
+            'messages'                     => $messages,
             'carrier'                      => new Carrier($order->id_carrier),
             'history'                      => $history,
             'states'                       => OrderState::getOrderStates($this->context->language->id),


### PR DESCRIPTION
## Summary
- allow uploading multiple attachments from order and customer service replies
- store attachments alongside customer messages and expose download links
- show attached files in order message logs and include them in outgoing emails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343a5428f0832d927685fd7949248c)