### PR TITLE
Add option to group ordered products by reference

### DIFF
--- a/controllers/admin/AdminOrderPreferencesController.php
+++ b/controllers/admin/AdminOrderPreferencesController.php
@@ -161,6 +161,13 @@ class AdminOrderPreferencesControllerCore extends AdminController
                         'identifier' => 'id',
                         'list'       => $contacts,
                     ],
+                    'TB_ORDER_PRODUCT_GROUPING' => [
+                        'title'      => $this->l('Group ordered products by reference'),
+                        'hint'       => $this->l('Order products with the same reference together in the admin order view to speed up picking.'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                    ],
                 ],
                 'submit' => ['title' => $this->l('Save')],
             ],

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -3309,7 +3309,8 @@ class AdminOrdersControllerCore extends AdminController
     {
         $products = $order->getProducts();
 
-        foreach ($products as &$product) {
+        foreach ($products as $key => &$product) {
+            $product['_order_key'] = $key;
             if ($product['image'] instanceof Image) {
                 $imageId = (int)$product['image']->id;
                 $imagePath = ImageManager::getProductImageThumbnailFilePath($imageId);
@@ -3321,8 +3322,39 @@ class AdminOrdersControllerCore extends AdminController
                 }
             }
         }
+        unset($product);
 
-        ksort($products);
+        if (Configuration::get('TB_ORDER_PRODUCT_GROUPING')) {
+            $products = $this->sortProductsByReference($products);
+        } else {
+            ksort($products);
+        }
+
+        foreach ($products as &$product) {
+            unset($product['_order_key']);
+        }
+        unset($product);
+
+        return $products;
+    }
+
+    /**
+     * Sort order products by product reference (product id) while keeping the original order as fallback
+     *
+     * @param array $products
+     * @return array
+     */
+    protected function sortProductsByReference(array $products)
+    {
+        uasort($products, function (array $firstProduct, array $secondProduct) {
+            $idComparison = (int)$firstProduct['product_id'] <=> (int)$secondProduct['product_id'];
+
+            if ($idComparison !== 0) {
+                return $idComparison;
+            }
+
+            return $firstProduct['_order_key'] <=> $secondProduct['_order_key'];
+        });
 
         return $products;
     }


### PR DESCRIPTION
## Summary
- add a back office preference to group ordered products by reference during order picking
- sort products in AdminOrders by product id when the preference is enabled while preserving existing ordering for ties

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693723d380d0832da86414a56ff1c424)