### PR TITLE
Add option to sort admin order products by product ID

### DIFF
--- a/controllers/admin/AdminOrderPreferencesController.php
+++ b/controllers/admin/AdminOrderPreferencesController.php
@@ -161,6 +161,13 @@ class AdminOrderPreferencesControllerCore extends AdminController
                         'identifier' => 'id',
                         'list'       => $contacts,
                     ],
+                    'PS_ORDER_ADMIN_PRODUCTS_BY_ID' => [
+                        'title'      => $this->l('Group products by product ID in back office orders'),
+                        'hint'       => $this->l('When enabled, products in back office order detail are sorted by product ID to make picking easier.'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                    ],
                 ],
                 'submit' => ['title' => $this->l('Save')],
             ],

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -3322,7 +3322,20 @@ class AdminOrdersControllerCore extends AdminController
             }
         }
 
-        ksort($products);
+        if (Configuration::get('PS_ORDER_ADMIN_PRODUCTS_BY_ID')) {
+            $originalOrder = array_keys($products);
+            $positions = array_flip($originalOrder);
+
+            uasort($products, function ($a, $b) use ($positions) {
+                if ($a['product_id'] === $b['product_id']) {
+                    return $positions[$a['id_order_detail']] <=> $positions[$b['id_order_detail']];
+                }
+
+                return $a['product_id'] <=> $b['product_id'];
+            });
+        } else {
+            ksort($products);
+        }
 
         return $products;
     }


### PR DESCRIPTION
## Summary
- add a configuration toggle in order preferences to group products by product ID in back office order pages
- sort products in admin order details by product ID when the toggle is enabled while preserving existing ordering within each product

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693723d380d0832da86414a56ff1c424)