### PR TITLE
Add option to group order products by product ID in admin view

### DIFF
--- a/controllers/admin/AdminOrderPreferencesController.php
+++ b/controllers/admin/AdminOrderPreferencesController.php
@@ -161,6 +161,13 @@ class AdminOrderPreferencesControllerCore extends AdminController
                         'identifier' => 'id',
                         'list'       => $contacts,
                     ],
+                    'PS_ORDER_SORT_PRODUCTS_BY_ID' => [
+                        'title'      => $this->l('Sort products in order view by product ID'),
+                        'hint'       => $this->l('Groups products with the same product ID together on the order page to aid picking.'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                    ],
                 ],
                 'submit' => ['title' => $this->l('Save')],
             ],

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -3309,7 +3309,9 @@ class AdminOrdersControllerCore extends AdminController
     {
         $products = $order->getProducts();
 
-        foreach ($products as &$product) {
+        $sortByProductId = (bool)Configuration::get('PS_ORDER_SORT_PRODUCTS_BY_ID');
+
+        foreach ($products as $position => &$product) {
             if ($product['image'] instanceof Image) {
                 $imageId = (int)$product['image']->id;
                 $imagePath = ImageManager::getProductImageThumbnailFilePath($imageId);
@@ -3320,9 +3322,26 @@ class AdminOrdersControllerCore extends AdminController
                     $product['image_size'] = false;
                 }
             }
+            if ($sortByProductId) {
+                $product['_original_position'] = $position;
+            }
         }
 
-        ksort($products);
+        if ($sortByProductId) {
+            usort($products, function ($left, $right) {
+                if ($left['product_id'] === $right['product_id']) {
+                    return $left['_original_position'] <=> $right['_original_position'];
+                }
+
+                return ($left['product_id'] < $right['product_id']) ? -1 : 1;
+            });
+
+            foreach ($products as &$product) {
+                unset($product['_original_position']);
+            }
+        } else {
+            ksort($products);
+        }
 
         return $products;
     }


### PR DESCRIPTION
## Summary
- add a configuration toggle in order preferences to sort order products by product ID
- update the admin order view to group products by product ID when the toggle is enabled while preserving existing ordering otherwise

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693723d380d0832da86414a56ff1c424)