### PR TITLE
Add option to group products by ID in admin orders

### DIFF
--- a/controllers/admin/AdminOrderPreferencesController.php
+++ b/controllers/admin/AdminOrderPreferencesController.php
@@ -161,6 +161,13 @@ class AdminOrderPreferencesControllerCore extends AdminController
                         'identifier' => 'id',
                         'list'       => $contacts,
                     ],
+                    'PS_ORDER_PRODUCTS_SORT_BY_ID' => [
+                        'title'      => $this->l('Order products by product ID'),
+                        'hint'       => $this->l('When enabled, products in an order are grouped by product reference in the admin order view.'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                    ],
                 ],
                 'submit' => ['title' => $this->l('Save')],
             ],

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -3322,7 +3322,17 @@ class AdminOrdersControllerCore extends AdminController
             }
         }
 
-        ksort($products);
+        if (Configuration::get('PS_ORDER_PRODUCTS_SORT_BY_ID')) {
+            uasort($products, function (array $first, array $second) {
+                if ($first['product_id'] === $second['product_id']) {
+                    return $first['id_order_detail'] <=> $second['id_order_detail'];
+                }
+
+                return $first['product_id'] <=> $second['product_id'];
+            });
+        } else {
+            ksort($products);
+        }
 
         return $products;
     }


### PR DESCRIPTION
## Summary
- add a configuration switch in Order Preferences to control sorting of products in the admin order view
- when enabled, group order products by product ID before falling back to the existing order detail sorting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693723d380d0832da86414a56ff1c424)