### PR TITLE
Add multishop overwrite confirmation for category saves

### DIFF
--- a/admin-dev/themes/default/template/controllers/categories/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/categories/helpers/form/form.tpl
@@ -26,6 +26,60 @@
 
 {block name="script"}
 	var ps_force_friendly_product = false;
+	{if $multishop_overwrite_enabled}
+		$(function () {
+			var $form = $('#category_form');
+			var $overwriteInput = $('#multishop_overwrite');
+			var labels = {$multishop_overwrite_field_labels|json_encode};
+			var checkUrl = '{$current|escape:'javascript':'UTF-8'}&token={$token|escape:'javascript':'UTF-8'}';
+			var $modal = $('#category-multishop-overwrite-modal');
+			var $details = $('#category-multishop-overwrite-details');
+
+			var renderDetails = function (shops) {
+				var html = '<ul class="list-unstyled">';
+				$.each(shops, function (index, shop) {
+					var fieldLabels = $.map(shop.fields, function (field) {
+						return labels[field] || field;
+					});
+					html += '<li><strong>' + shop.name + '</strong>: ' + fieldLabels.join(', ') + '</li>';
+				});
+				html += '</ul>';
+				$details.html(html);
+			};
+
+			$form.on('submit', function (event) {
+				if ($overwriteInput.val()) {
+					return true;
+				}
+
+				event.preventDefault();
+				var data = $form.serializeArray();
+				data.push({name: 'ajax', value: 1});
+				data.push({name: 'action', value: 'CategoryShopDifferences'});
+				$.post(checkUrl, $.param(data), function (response) {
+					if (response && response.hasDifferences) {
+						renderDetails(response.shops);
+						$modal.modal('show');
+					} else {
+						$overwriteInput.val('all');
+						$form[0].submit();
+					}
+				}, 'json');
+			});
+
+			$('#category-multishop-overwrite-all').on('click', function () {
+				$overwriteInput.val('all');
+				$modal.modal('hide');
+				$form[0].submit();
+			});
+
+			$('#category-multishop-overwrite-empty').on('click', function () {
+				$overwriteInput.val('empty');
+				$modal.modal('hide');
+				$form[0].submit();
+			});
+		});
+	{/if}
 {/block}
 
 {block name="input"}
@@ -58,4 +112,28 @@
 	{if ($input.name == 'thumb')}
 	{$displayBackOfficeCategory}
 	{/if}
+{/block}
+
+{block name="footer"}
+	<input type="hidden" name="multishop_overwrite" id="multishop_overwrite" value="" />
+	{$smarty.block.parent}
+	<div class="modal fade" id="category-multishop-overwrite-modal" tabindex="-1" role="dialog" aria-labelledby="category-multishop-overwrite-title">
+		<div class="modal-dialog" role="document">
+			<div class="modal-content">
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close'}"><span aria-hidden="true">&times;</span></button>
+					<h4 class="modal-title" id="category-multishop-overwrite-title">{l s='Overwrite per-shop category values?'}</h4>
+				</div>
+				<div class="modal-body">
+					<p>{l s='This category has different values in some shops. Saving now will overwrite those values.'}</p>
+					<div id="category-multishop-overwrite-details"></div>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-default" data-dismiss="modal">{l s='Cancel'}</button>
+					<button type="button" class="btn btn-default" id="category-multishop-overwrite-empty">{l s='Fill empty values only'}</button>
+					<button type="button" class="btn btn-primary" id="category-multishop-overwrite-all">{l s='Overwrite all shops'}</button>
+				</div>
+			</div>
+		</div>
+	</div>
 {/block}

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -39,6 +39,8 @@ class AdminCategoriesControllerCore extends AdminController
     const DELETE_MODE_DELETE = 'delete';
     const DELETE_MODE_LINK = 'link';
     const DELETE_MODE_LINK_AND_DISABLE = 'linkanddisable';
+    const MULTISHOP_OVERWRITE_ALL = 'all';
+    const MULTISHOP_OVERWRITE_EMPTY = 'empty';
 
     /**
      * @var bool does the product have to be removed during the delete process
@@ -705,6 +707,8 @@ class AdminCategoriesControllerCore extends AdminController
         $this->tpl_form_vars['shared_category'] = Validate::isLoadedObject($obj) && $obj->hasMultishopEntries();
         $this->tpl_form_vars['PS_ALLOW_ACCENTED_CHARS_URL'] = (int) Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL');
         $this->tpl_form_vars['displayBackOfficeCategory'] = Hook::displayHook('displayBackOfficeCategory');
+        $this->tpl_form_vars['multishop_overwrite_enabled'] = $this->shouldCheckMultishopOverwrite();
+        $this->tpl_form_vars['multishop_overwrite_field_labels'] = $this->getMultishopTextFieldLabels();
 
         // Display this field only if multistore option is enabled
         if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE') && Tools::isSubmit('add'.$this->table.'root')) {
@@ -775,6 +779,215 @@ class AdminCategoriesControllerCore extends AdminController
     }
 
     /**
+     * @throws PrestaShopException
+     */
+    public function ajaxProcessCategoryShopDifferences()
+    {
+        if (!$this->shouldCheckMultishopOverwrite()) {
+            $this->ajaxDie(json_encode(['hasDifferences' => false, 'shops' => []]));
+        }
+
+        $idCategory = Tools::getIntValue($this->identifier);
+        if (!$idCategory) {
+            $this->ajaxDie(json_encode(['hasDifferences' => false, 'shops' => []]));
+        }
+
+        $submittedValues = $this->getSubmittedTextFieldValues();
+        $differences = $this->getTextFieldDifferences($idCategory, $submittedValues);
+        $shops = [];
+
+        foreach ($differences as $idShop => $fields) {
+            $shop = Shop::getShop($idShop);
+            $shops[] = [
+                'id_shop' => (int) $idShop,
+                'name' => $shop ? $shop['name'] : sprintf($this->l('Shop %d'), (int) $idShop),
+                'fields' => array_values($fields),
+            ];
+        }
+
+        $this->ajaxDie(json_encode([
+            'hasDifferences' => !empty($shops),
+            'shops' => $shops,
+        ]));
+    }
+
+    /**
+     * @return bool
+     */
+    protected function shouldCheckMultishopOverwrite()
+    {
+        return Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE')
+            && Shop::isFeatureActive()
+            && Shop::getContext() === Shop::CONTEXT_ALL
+            && (int) Tools::getIntValue($this->identifier) > 0;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getMultishopTextFields()
+    {
+        return [
+            'name',
+            'description',
+            'additional_description',
+            'link_rewrite',
+            'meta_title',
+            'meta_keywords',
+            'meta_description',
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getMultishopTextFieldLabels()
+    {
+        return [
+            'name' => $this->l('Name'),
+            'description' => $this->l('Description'),
+            'additional_description' => $this->l('Additional description'),
+            'link_rewrite' => $this->l('Friendly URL'),
+            'meta_title' => $this->l('Meta title'),
+            'meta_keywords' => $this->l('Meta keywords'),
+            'meta_description' => $this->l('Meta description'),
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getSubmittedTextFieldValues()
+    {
+        $values = [];
+        $languages = Language::getLanguages(false);
+        foreach ($this->getMultishopTextFields() as $field) {
+            foreach ($languages as $language) {
+                $idLang = (int) $language['id_lang'];
+                $values[$field][$idLang] = (string) Tools::getValue($field.'_'.$idLang, '');
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param int $idCategory
+     *
+     * @return array
+     */
+    protected function getCategoryLangValues($idCategory)
+    {
+        $shopIds = Shop::getContextListShopID();
+        if (empty($shopIds)) {
+            return [];
+        }
+
+        $fields = $this->getMultishopTextFields();
+        $query = 'SELECT id_shop, id_lang, '.implode(', ', array_map('bqSQL', $fields)).'
+            FROM '._DB_PREFIX_.'category_lang
+            WHERE id_category = '.(int) $idCategory.'
+            AND id_shop IN ('.implode(', ', array_map('intval', $shopIds)).')';
+
+        $rows = Db::getInstance()->executeS($query);
+        $values = [];
+
+        foreach ($rows as $row) {
+            $idShop = (int) $row['id_shop'];
+            $idLang = (int) $row['id_lang'];
+            foreach ($fields as $field) {
+                $values[$idShop][$idLang][$field] = (string) $row[$field];
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param int $idCategory
+     * @param array $submittedValues
+     *
+     * @return array
+     */
+    protected function getTextFieldDifferences($idCategory, array $submittedValues)
+    {
+        $storedValues = $this->getCategoryLangValues($idCategory);
+        $differences = [];
+        $languages = Language::getLanguages(false);
+
+        foreach ($storedValues as $idShop => $langValues) {
+            foreach ($this->getMultishopTextFields() as $field) {
+                foreach ($languages as $language) {
+                    $idLang = (int) $language['id_lang'];
+                    $submitted = isset($submittedValues[$field][$idLang]) ? (string) $submittedValues[$field][$idLang] : '';
+                    $stored = isset($langValues[$idLang][$field]) ? (string) $langValues[$idLang][$field] : '';
+                    if ($submitted !== $stored) {
+                        $differences[$idShop][$field] = $field;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $differences;
+    }
+
+    /**
+     * @param int $idCategory
+     * @param array $originalValues
+     * @param array $submittedValues
+     *
+     * @return void
+     */
+    protected function restoreNonEmptyTextFields($idCategory, array $originalValues, array $submittedValues)
+    {
+        if (empty($originalValues)) {
+            return;
+        }
+
+        $fields = $this->getMultishopTextFields();
+        $languages = Language::getLanguages(false);
+        $conn = Db::getInstance();
+
+        foreach ($originalValues as $idShop => $langValues) {
+            foreach ($languages as $language) {
+                $idLang = (int) $language['id_lang'];
+                if (!isset($langValues[$idLang])) {
+                    continue;
+                }
+
+                $restore = [];
+                foreach ($fields as $field) {
+                    $original = isset($langValues[$idLang][$field]) ? (string) $langValues[$idLang][$field] : '';
+                    if (!$this->isTextValueEmpty($original)) {
+                        $restore[$field] = $original;
+                    } else {
+                        $submitted = isset($submittedValues[$field][$idLang]) ? (string) $submittedValues[$field][$idLang] : '';
+                        if ($this->isTextValueEmpty($submitted)) {
+                            $restore[$field] = $submitted;
+                        }
+                    }
+                }
+
+                if (!empty($restore)) {
+                    $where = 'id_category = '.(int) $idCategory.' AND id_lang = '.(int) $idLang.' AND id_shop = '.(int) $idShop;
+                    $conn->update('category_lang', $restore, $where);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return bool
+     */
+    protected function isTextValueEmpty($value)
+    {
+        return trim(strip_tags((string) $value)) === '';
+    }
+
+    /**
      * @return bool
      *
      * @throws PrestaShopDatabaseException
@@ -787,6 +1000,40 @@ class AdminCategoriesControllerCore extends AdminController
         }
 
         return parent::postProcess();
+    }
+
+    /**
+     * @return ObjectModel|false
+     *
+     * @throws PrestaShopException
+     */
+    public function processUpdate()
+    {
+        if ($this->shouldCheckMultishopOverwrite()) {
+            $idCategory = Tools::getIntValue($this->identifier);
+            $submittedValues = $this->getSubmittedTextFieldValues();
+            $differences = $this->getTextFieldDifferences($idCategory, $submittedValues);
+            $overwriteMode = (string) Tools::getValue('multishop_overwrite');
+
+            if (empty($overwriteMode) && !empty($differences)) {
+                $this->errors[] = $this->l('This category has different values across shops. Please confirm how to proceed before saving.');
+                $this->display = 'edit';
+
+                return false;
+            }
+
+            if ($overwriteMode === static::MULTISHOP_OVERWRITE_EMPTY) {
+                $originalValues = $this->getCategoryLangValues($idCategory);
+                $result = parent::processUpdate();
+                if ($result && empty($this->errors)) {
+                    $this->restoreNonEmptyTextFields($idCategory, $originalValues, $submittedValues);
+                }
+
+                return $result;
+            }
+        }
+
+        return parent::processUpdate();
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Prevent accidental overwrites of per-shop category text fields when saving a category in the "All shops" multistore context by warning merchants and offering overwrite options.
- Provide choices to `Overwrite all shops`, `Fill empty values only` (preserve existing per-shop non-empty values), or `Cancel` before committing changes across shops.

### Description
- Add constants `MULTISHOP_OVERWRITE_ALL` and `MULTISHOP_OVERWRITE_EMPTY` and multishop-aware save logic in `AdminCategoriesController` via an overridden `processUpdate` that blocks save when differences exist unless an overwrite mode is supplied.
- Add an AJAX handler `ajaxProcessCategoryShopDifferences` and helper methods (`shouldCheckMultishopOverwrite`, `getMultishopTextFields`, `getMultishopTextFieldLabels`, `getSubmittedTextFieldValues`, `getCategoryLangValues`, `getTextFieldDifferences`, `restoreNonEmptyTextFields`, `isTextValueEmpty`) to detect per-shop differences and to implement the "fill empty values only" behavior that restores non-empty per-shop values after a save.
- Expose template variables from `renderForm` and modify the category form template to add a hidden `multishop_overwrite` input, a confirmation modal, and client-side JS that requests diffs, shows the modal with affected shops/fields, and submits the chosen overwrite mode.
- Minor SQL safety improvement using `bqSQL` when building the `category_lang` select list for text fields.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ad86bcf74832db6cabea7a93037f1)