### PR TITLE
Add multishop overwrite confirmation when editing categories in all-shops context

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -42,6 +42,9 @@
 	{if !empty($submit_action)}
 		<input type="hidden" name="{$submit_action}" value="1" />
 	{/if}
+	{if isset($multishop_overwrite)}
+		<input type="hidden" name="multishop_overwrite_action" id="multishop_overwrite_action" value="" />
+	{/if}
 	{foreach $fields as $f => $fieldset}
 		{block name="fieldset"}
 		{capture name='fieldset_name'}{counter name='fieldset_name'}{/capture}
@@ -816,6 +819,73 @@
 </form>
 {/block}
 {block name="after"}{/block}
+{if isset($multishop_overwrite)}
+<div class="modal fade" id="multishop-overwrite-modal" tabindex="-1" role="dialog" aria-labelledby="multishop-overwrite-title">
+	<div class="modal-dialog" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close'}"><span aria-hidden="true">&times;</span></button>
+				<h4 class="modal-title" id="multishop-overwrite-title">{$multishop_overwrite.title|escape:'html':'UTF-8'}</h4>
+			</div>
+			<div class="modal-body">
+				<p>{$multishop_overwrite.message|escape:'html':'UTF-8'}</p>
+				<ul class="list-unstyled">
+					{foreach from=$multishop_overwrite.shops item=shop}
+						<li>
+							<strong>{$shop.name|escape:'html':'UTF-8'}</strong>
+							{if $shop.fields|count}
+								<ul>
+									{foreach from=$shop.fields item=field}
+										<li>{$field|escape:'html':'UTF-8'}</li>
+									{/foreach}
+								</ul>
+							{/if}
+						</li>
+					{/foreach}
+				</ul>
+			</div>
+			<div class="modal-footer">
+				<button type="button" class="btn btn-primary" id="multishop-overwrite-confirm-all">{$multishop_overwrite.confirm_all|escape:'html':'UTF-8'}</button>
+				<button type="button" class="btn btn-default" id="multishop-overwrite-confirm-empty">{$multishop_overwrite.confirm_empty|escape:'html':'UTF-8'}</button>
+				<button type="button" class="btn btn-link" id="multishop-overwrite-cancel" data-dismiss="modal">{$multishop_overwrite.cancel|escape:'html':'UTF-8'}</button>
+			</div>
+		</div>
+	</div>
+</div>
+<script type="text/javascript">
+	$(document).ready(function () {
+		var $action = $('#multishop_overwrite_action');
+		if (!$action.length) {
+			return;
+		}
+		var $form = $action.closest('form');
+		var $modal = $('#multishop-overwrite-modal');
+		var isSubmitting = false;
+
+		$form.on('submit', function (event) {
+			if (isSubmitting) {
+				return;
+			}
+			if (!$action.val()) {
+				event.preventDefault();
+				$modal.modal('show');
+			}
+		});
+
+		$('#multishop-overwrite-confirm-all').on('click', function () {
+			isSubmitting = true;
+			$action.val('overwrite_all');
+			$form.submit();
+		});
+
+		$('#multishop-overwrite-confirm-empty').on('click', function () {
+			isSubmitting = true;
+			$action.val('overwrite_empty');
+			$form.submit();
+		});
+	});
+</script>
+{/if}
 
 {if isset($tinymce) && $tinymce}
 <script type="text/javascript">

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -39,6 +39,8 @@ class AdminCategoriesControllerCore extends AdminController
     const DELETE_MODE_DELETE = 'delete';
     const DELETE_MODE_LINK = 'link';
     const DELETE_MODE_LINK_AND_DISABLE = 'linkanddisable';
+    const MULTISHOP_OVERWRITE_ACTION_ALL = 'overwrite_all';
+    const MULTISHOP_OVERWRITE_ACTION_EMPTY = 'overwrite_empty';
 
     /**
      * @var bool does the product have to be removed during the delete process
@@ -69,6 +71,11 @@ class AdminCategoriesControllerCore extends AdminController
      * @var string
      */
     protected $delete_mode;
+
+    /**
+     * @var array|null
+     */
+    protected $multishopOverwriteData = null;
 
     /**
      * AdminCategoriesControllerCore constructor.
@@ -705,6 +712,9 @@ class AdminCategoriesControllerCore extends AdminController
         $this->tpl_form_vars['shared_category'] = Validate::isLoadedObject($obj) && $obj->hasMultishopEntries();
         $this->tpl_form_vars['PS_ALLOW_ACCENTED_CHARS_URL'] = (int) Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL');
         $this->tpl_form_vars['displayBackOfficeCategory'] = Hook::displayHook('displayBackOfficeCategory');
+        if ($this->multishopOverwriteData) {
+            $this->tpl_form_vars['multishop_overwrite'] = $this->multishopOverwriteData;
+        }
 
         // Display this field only if multistore option is enabled
         if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE') && Tools::isSubmit('add'.$this->table.'root')) {
@@ -854,6 +864,239 @@ class AdminCategoriesControllerCore extends AdminController
         }
 
         return false;
+    }
+
+    /**
+     * @return ObjectModel|false
+     *
+     * @throws PrestaShopException
+     */
+    public function processUpdate()
+    {
+        if (!$this->shouldCheckMultishopOverwrite()) {
+            return parent::processUpdate();
+        }
+
+        $idCategory = Tools::getIntValue($this->identifier);
+        $action = Tools::getValue('multishop_overwrite_action');
+
+        if (!$action) {
+            $differences = $this->getMultishopOverwriteDifferences($idCategory);
+            if (!empty($differences['shops'])) {
+                $this->multishopOverwriteData = $differences;
+                $this->_redirect = false;
+                $this->display = 'edit';
+
+                return false;
+            }
+
+            return parent::processUpdate();
+        }
+
+        if ($action === static::MULTISHOP_OVERWRITE_ACTION_EMPTY) {
+            $shopIds = $this->getAssociatedShopIds($idCategory);
+            $existingValues = $this->getMultishopCategoryLangValues($idCategory, $shopIds);
+            $result = parent::processUpdate();
+            if ($result) {
+                $this->restoreNonEmptyMultishopValues($idCategory, $existingValues);
+            }
+
+            return $result;
+        }
+
+        return parent::processUpdate();
+    }
+
+    /**
+     * @return bool
+     */
+    protected function shouldCheckMultishopOverwrite()
+    {
+        return Shop::isFeatureActive()
+            && Shop::getContext() === Shop::CONTEXT_ALL
+            && Tools::getIntValue($this->identifier) > 0;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getMultishopTextFields()
+    {
+        return [
+            'name' => $this->l('Name'),
+            'description' => $this->l('Description'),
+            'additional_description' => $this->l('Additional description'),
+            'meta_title' => $this->l('Meta title'),
+            'meta_description' => $this->l('Meta description'),
+            'meta_keywords' => $this->l('Meta keywords'),
+            'link_rewrite' => $this->l('Friendly URL'),
+        ];
+    }
+
+    /**
+     * @param int $idCategory
+     *
+     * @return array
+     */
+    protected function getAssociatedShopIds($idCategory)
+    {
+        $shopIds = [];
+        foreach (Category::getShopsByCategory($idCategory) as $shopRow) {
+            $shopIds[] = (int) $shopRow['id_shop'];
+        }
+
+        return array_values(array_unique($shopIds));
+    }
+
+    /**
+     * @param int $idCategory
+     *
+     * @return array
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    protected function getMultishopOverwriteDifferences($idCategory)
+    {
+        $shopIds = $this->getAssociatedShopIds($idCategory);
+        if (!$shopIds) {
+            return [];
+        }
+
+        $shops = Shop::getShops(false);
+        $shopNames = [];
+        foreach ($shopIds as $shopId) {
+            if (isset($shops[$shopId])) {
+                $shopNames[$shopId] = $shops[$shopId]['name'];
+            }
+        }
+
+        $languages = Language::getLanguages(false);
+        $fieldLabels = $this->getMultishopTextFields();
+        $existingValues = $this->getMultishopCategoryLangValues($idCategory, $shopIds);
+        $differences = [];
+
+        foreach ($shopNames as $shopId => $shopName) {
+            $fields = [];
+            foreach ($languages as $language) {
+                $languageId = (int) $language['id_lang'];
+                foreach ($fieldLabels as $field => $label) {
+                    $submitted = (string) Tools::getValue($field.'_'.$languageId, '');
+                    $existing = (string) ($existingValues[$shopId][$languageId][$field] ?? '');
+                    if ($submitted !== $existing) {
+                        $fields[] = sprintf('%s (%s)', $label, $language['name']);
+                    }
+                }
+            }
+
+            if ($fields) {
+                $differences[] = [
+                    'name' => $shopName,
+                    'fields' => array_values(array_unique($fields)),
+                ];
+            }
+        }
+
+        if (!$differences) {
+            return [];
+        }
+
+        return [
+            'title' => $this->l('Different values detected'),
+            'message' => $this->l('This category has different values per shop. Saving now will overwrite those values.'),
+            'confirm_all' => $this->l('Save for all shops'),
+            'confirm_empty' => $this->l('Save only empty values'),
+            'cancel' => $this->l('Cancel'),
+            'shops' => $differences,
+        ];
+    }
+
+    /**
+     * @param int $idCategory
+     * @param int[] $shopIds
+     *
+     * @return array
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    protected function getMultishopCategoryLangValues($idCategory, array $shopIds)
+    {
+        if (!$shopIds) {
+            return [];
+        }
+
+        $fields = array_keys($this->getMultishopTextFields());
+        $selectFields = array_map(function ($field) {
+            return 'cl.`'.$field.'`';
+        }, $fields);
+
+        $query = (new DbQuery())
+            ->select('cl.`id_shop`, cl.`id_lang`, '.implode(', ', $selectFields))
+            ->from('category_lang', 'cl')
+            ->where('cl.`id_category` = '.(int) $idCategory)
+            ->where('cl.`id_shop` IN ('.implode(', ', array_map('intval', $shopIds)).')');
+
+        $values = [];
+        foreach (Db::readOnly()->getArray($query) as $row) {
+            $shopId = (int) $row['id_shop'];
+            $langId = (int) $row['id_lang'];
+            foreach ($fields as $field) {
+                $values[$shopId][$langId][$field] = $row[$field];
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param int $idCategory
+     * @param array $existingValues
+     *
+     * @return void
+     *
+     * @throws PrestaShopException
+     */
+    protected function restoreNonEmptyMultishopValues($idCategory, array $existingValues)
+    {
+        if (!$existingValues) {
+            return;
+        }
+
+        $fields = array_keys($this->getMultishopTextFields());
+        foreach ($existingValues as $shopId => $languages) {
+            foreach ($languages as $langId => $values) {
+                $updateData = [];
+                foreach ($fields as $field) {
+                    $value = $values[$field] ?? '';
+                    if (!$this->isMultishopValueEmpty($value)) {
+                        $updateData[$field] = pSQL($value, true);
+                    }
+                }
+
+                if ($updateData) {
+                    Db::getInstance()->update(
+                        'category_lang',
+                        $updateData,
+                        'id_category = '.(int) $idCategory.' AND id_shop = '.(int) $shopId.' AND id_lang = '.(int) $langId
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    protected function isMultishopValueEmpty($value)
+    {
+        if ($value === null) {
+            return true;
+        }
+
+        return trim(strip_tags((string) $value)) === '';
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Prevent accidental overwrites of per-shop category text fields when saving a category in the all-shops context by prompting the merchant with overwrite choices.
- Provide options to either overwrite values for all shops, only populate empty shop values, or cancel the save to avoid data loss across shops.

### Description
- Add overwrite flow to `AdminCategoriesControllerCore` by introducing `MULTISHOP_OVERWRITE_ACTION_*` constants, a `multishopOverwriteData` holder, and an override of `processUpdate()` that detects per-shop differences via `getMultishopOverwriteDifferences()` and shows the form again when differences exist.
- Implement helper methods `shouldCheckMultishopOverwrite()`, `getMultishopTextFields()`, `getAssociatedShopIds()`, `getMultishopCategoryLangValues()`, `restoreNonEmptyMultishopValues()` and `isMultishopValueEmpty()` to identify changed text fields and to support the `overwrite_empty` behavior which preserves non-empty shop-specific values.
- Populate the template variable `multishop_overwrite` in the controller so the form layer can render UI, and add a hidden `multishop_overwrite_action` field plus a Bootstrap modal and JS in `admin-dev/themes/default/template/helpers/form/form.tpl` that intercepts submits and offers the merchant three choices: `Save for all shops`, `Save only empty values`, or `Cancel`.
- When `overwrite_empty` is chosen the controller saves the posted values and then restores previously non-empty per-shop values so only empty fields are filled from the all-shops submission.

### Testing
- No automated tests were executed for this change (no test run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ad86bcf74832db6cabea7a93037f1)