### PR TITLE
Add multishop overwrite confirmation for category text fields

### DIFF
--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -740,7 +740,7 @@ class AdminCategoriesControllerCore extends AdminController
                     'categoryMultishopOverwriteActionField' => 'category_multishop_overwrite_action',
                     'categoryMultishopOverwriteTitle' => $this->l('Different values found in shops'),
                     'categoryMultishopOverwriteMessage' => $this->l('This category contains different text values per shop. Choose how to proceed:'),
-                    'categoryMultishopOverwriteConfirmLabel' => $this->l('Overwrite all shops'),
+                    'categoryMultishopOverwriteConfirmLabel' => $this->l('Overwrite those fields for all shops'),
                     'categoryMultishopOverwriteEmptyLabel' => $this->l('Only fill empty values'),
                     'categoryMultishopOverwriteCancelLabel' => $this->l('Cancel'),
                     'categoryMultishopOverwriteShopLabel' => $this->l('Shop'),
@@ -910,7 +910,7 @@ class AdminCategoriesControllerCore extends AdminController
         if ($this->shouldCheckMultishopOverwrite() && !$this->multishopOverwriteAction) {
             $this->multishopOverwriteData = $this->buildMultishopOverwriteData();
             if (!empty($this->multishopOverwriteData['differences'])) {
-                $this->warnings[] = $this->l('This category has different text values in some shops. Review the list before saving.');
+                $this->warnings[] = $this->l('This category already has different text values for some fields in some shops. When saving, please review the differences and decide on the appropriate action.');
                 return false;
             }
         }
@@ -940,8 +940,7 @@ class AdminCategoriesControllerCore extends AdminController
     protected function shouldCheckMultishopOverwrite(): bool
     {
         return Shop::isFeatureActive()
-            && Shop::getContext() === Shop::CONTEXT_ALL
-            && $this->display === 'edit';
+            && Shop::getContext() === Shop::CONTEXT_ALL;
     }
 
     /**

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -39,6 +39,8 @@ class AdminCategoriesControllerCore extends AdminController
     const DELETE_MODE_DELETE = 'delete';
     const DELETE_MODE_LINK = 'link';
     const DELETE_MODE_LINK_AND_DISABLE = 'linkanddisable';
+    const MULTISHOP_OVERWRITE_ALL = 'overwrite_all';
+    const MULTISHOP_OVERWRITE_EMPTY = 'overwrite_empty';
 
     /**
      * @var bool does the product have to be removed during the delete process
@@ -69,6 +71,16 @@ class AdminCategoriesControllerCore extends AdminController
      * @var string
      */
     protected $delete_mode;
+
+    /**
+     * @var array|null
+     */
+    protected $multishopOverwriteData = null;
+
+    /**
+     * @var string|null
+     */
+    protected $multishopOverwriteAction = null;
 
     /**
      * AdminCategoriesControllerCore constructor.
@@ -219,6 +231,17 @@ class AdminCategoriesControllerCore extends AdminController
                 ];
             }
         }
+    }
+
+    /**
+     * @return void
+     *
+     * @throws PrestaShopException
+     */
+    public function setMedia()
+    {
+        parent::setMedia();
+        $this->addJS(_PS_JS_DIR_.'admin/categories_multishop_overwrite.js');
     }
 
     /**
@@ -676,6 +699,10 @@ class AdminCategoriesControllerCore extends AdminController
                     'hint'     => $this->l('Only letters, numbers, underscore (_) and the minus (-) character are allowed.'),
                 ],
                 [
+                    'type' => 'hidden',
+                    'name' => 'category_multishop_overwrite_action',
+                ],
+                [
                     'type'              => 'group',
                     'label'             => $this->l('Group access'),
                     'name'              => 'groupBox',
@@ -705,6 +732,21 @@ class AdminCategoriesControllerCore extends AdminController
         $this->tpl_form_vars['shared_category'] = Validate::isLoadedObject($obj) && $obj->hasMultishopEntries();
         $this->tpl_form_vars['PS_ALLOW_ACCENTED_CHARS_URL'] = (int) Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL');
         $this->tpl_form_vars['displayBackOfficeCategory'] = Hook::displayHook('displayBackOfficeCategory');
+
+        if ($this->multishopOverwriteData) {
+            Media::addJsDef(
+                [
+                    'categoryMultishopOverwriteData' => $this->multishopOverwriteData,
+                    'categoryMultishopOverwriteActionField' => 'category_multishop_overwrite_action',
+                    'categoryMultishopOverwriteTitle' => $this->l('Different values found in shops'),
+                    'categoryMultishopOverwriteMessage' => $this->l('This category contains different text values per shop. Choose how to proceed:'),
+                    'categoryMultishopOverwriteConfirmLabel' => $this->l('Overwrite all shops'),
+                    'categoryMultishopOverwriteEmptyLabel' => $this->l('Only fill empty values'),
+                    'categoryMultishopOverwriteCancelLabel' => $this->l('Cancel'),
+                    'categoryMultishopOverwriteShopLabel' => $this->l('Shop'),
+                ]
+            );
+        }
 
         // Display this field only if multistore option is enabled
         if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE') && Tools::isSubmit('add'.$this->table.'root')) {
@@ -854,6 +896,262 @@ class AdminCategoriesControllerCore extends AdminController
         }
 
         return false;
+    }
+
+    /**
+     * @return ObjectModel|false
+     *
+     * @throws PrestaShopException
+     */
+    public function processUpdate()
+    {
+        $this->multishopOverwriteAction = $this->getMultishopOverwriteAction();
+
+        if ($this->shouldCheckMultishopOverwrite() && !$this->multishopOverwriteAction) {
+            $this->multishopOverwriteData = $this->buildMultishopOverwriteData();
+            if (!empty($this->multishopOverwriteData['differences'])) {
+                $this->warnings[] = $this->l('This category has different text values in some shops. Review the list before saving.');
+                return false;
+            }
+        }
+
+        if ($this->multishopOverwriteAction === static::MULTISHOP_OVERWRITE_EMPTY) {
+            $idCategory = Tools::getIntValue($this->identifier);
+            if (!$idCategory) {
+                return parent::processUpdate();
+            }
+            $shopIds = Shop::getContextListShopID();
+            $fields = array_keys($this->getMultishopTextFields());
+            $storedValues = $this->getCategoryLangValuesByShop($idCategory, $shopIds, $fields);
+            $submittedValues = $this->getSubmittedLangValues($fields);
+            $result = parent::processUpdate();
+            if ($result) {
+                $this->restoreCategoryLangValues($idCategory, $shopIds, $storedValues, $submittedValues, $fields);
+            }
+            return $result;
+        }
+
+        return parent::processUpdate();
+    }
+
+    /**
+     * @return bool
+     */
+    protected function shouldCheckMultishopOverwrite(): bool
+    {
+        return Shop::isFeatureActive()
+            && Shop::getContext() === Shop::CONTEXT_ALL
+            && $this->display === 'edit';
+    }
+
+    /**
+     * @return string|null
+     */
+    protected function getMultishopOverwriteAction()
+    {
+        $action = Tools::getValue('category_multishop_overwrite_action');
+        if (in_array($action, [static::MULTISHOP_OVERWRITE_ALL, static::MULTISHOP_OVERWRITE_EMPTY], true)) {
+            return $action;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getMultishopTextFields(): array
+    {
+        return [
+            'name' => $this->l('Name'),
+            'description' => $this->l('Description'),
+            'additional_description' => $this->l('Additional description'),
+            'meta_title' => $this->l('Meta title'),
+            'meta_description' => $this->l('Meta description'),
+            'meta_keywords' => $this->l('Meta keywords'),
+            'link_rewrite' => $this->l('Friendly URL'),
+        ];
+    }
+
+    /**
+     * @param string[] $fields
+     *
+     * @return array
+     *
+     * @throws PrestaShopException
+     */
+    protected function getSubmittedLangValues(array $fields): array
+    {
+        $values = [];
+        $languages = Language::getLanguages(false);
+        foreach ($fields as $field) {
+            foreach ($languages as $language) {
+                $value = Tools::getValue($field.'_'.$language['id_lang']);
+                $values[$field][(int) $language['id_lang']] = $value === null ? '' : (string) $value;
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param int $idCategory
+     * @param int[] $shopIds
+     * @param string[] $fields
+     *
+     * @return array
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    protected function getCategoryLangValuesByShop(int $idCategory, array $shopIds, array $fields): array
+    {
+        if (!$shopIds) {
+            return [];
+        }
+        $selectFields = array_map(static function ($field) {
+            return 'cl.`'.bqSQL($field).'`';
+        }, $fields);
+
+        $query = (new DbQuery())
+            ->select('cl.`id_shop`, cl.`id_lang`, '.implode(', ', $selectFields))
+            ->from('category_lang', 'cl')
+            ->where('cl.`id_category` = '.(int) $idCategory)
+            ->where('cl.`id_shop` IN ('.implode(', ', array_map('intval', $shopIds)).')');
+
+        $rows = Db::readOnly()->getArray($query);
+        $values = [];
+        foreach ($rows as $row) {
+            $idShop = (int) $row['id_shop'];
+            $idLang = (int) $row['id_lang'];
+            foreach ($fields as $field) {
+                $values[$idShop][$idLang][$field] = (string) $row[$field];
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return array
+     *
+     * @throws PrestaShopException
+     */
+    protected function buildMultishopOverwriteData(): array
+    {
+        $idCategory = Tools::getIntValue($this->identifier);
+        if (!$idCategory) {
+            return [];
+        }
+
+        $shopIds = Shop::getContextListShopID();
+        $fields = $this->getMultishopTextFields();
+        $fieldNames = array_keys($fields);
+        $storedValues = $this->getCategoryLangValuesByShop($idCategory, $shopIds, $fieldNames);
+        $submittedValues = $this->getSubmittedLangValues($fieldNames);
+        $languages = Language::getLanguages(false);
+        $languageNames = [];
+        foreach ($languages as $language) {
+            $languageNames[(int) $language['id_lang']] = $language['name'];
+        }
+
+        $shops = Shop::getShops(true, null, true);
+        $shopNames = [];
+        foreach ($shops as $shop) {
+            $shopNames[(int) $shop['id_shop']] = $shop['name'];
+        }
+
+        $differences = [];
+        $hasMultipleLanguages = count($languages) > 1;
+        foreach ($shopIds as $shopId) {
+            $shopDifferences = [];
+            foreach ($languages as $language) {
+                $langId = (int) $language['id_lang'];
+                foreach ($fieldNames as $field) {
+                    $storedValue = $storedValues[$shopId][$langId][$field] ?? '';
+                    $submittedValue = $submittedValues[$field][$langId] ?? '';
+                    if ($storedValue !== $submittedValue) {
+                        $label = $fields[$field];
+                        if ($hasMultipleLanguages) {
+                            $label .= ' ('.$languageNames[$langId].')';
+                        }
+                        $shopDifferences[] = $label;
+                    }
+                }
+            }
+            if ($shopDifferences) {
+                $differences[] = [
+                    'id_shop' => (int) $shopId,
+                    'shop_name' => $shopNames[(int) $shopId] ?? sprintf($this->l('Shop %d'), (int) $shopId),
+                    'fields' => array_values(array_unique($shopDifferences)),
+                ];
+            }
+        }
+
+        return [
+            'differences' => $differences,
+        ];
+    }
+
+    /**
+     * @param int $idCategory
+     * @param int[] $shopIds
+     * @param array $storedValues
+     * @param array $submittedValues
+     * @param string[] $fields
+     *
+     * @return void
+     */
+    protected function restoreCategoryLangValues(
+        int $idCategory,
+        array $shopIds,
+        array $storedValues,
+        array $submittedValues,
+        array $fields
+    ): void {
+        $languages = Language::getLanguages(false);
+        foreach ($shopIds as $shopId) {
+            foreach ($languages as $language) {
+                $langId = (int) $language['id_lang'];
+                $restore = [];
+                foreach ($fields as $field) {
+                    $storedValue = $storedValues[$shopId][$langId][$field] ?? '';
+                    $submittedValue = $submittedValues[$field][$langId] ?? '';
+                    if (!$this->isValueEmpty($storedValue) && $storedValue !== $submittedValue) {
+                        $restore[$field] = pSQL($storedValue, true);
+                    }
+                }
+                if ($restore) {
+                    Db::getInstance()->update(
+                        'category_lang',
+                        $restore,
+                        'id_category = '.(int) $idCategory.' AND id_shop = '.(int) $shopId.' AND id_lang = '.(int) $langId,
+                        0,
+                        true
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @param string|null $value
+     *
+     * @return bool
+     */
+    protected function isValueEmpty($value): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return true;
+        }
+        $normalized = html_entity_decode(strip_tags($normalized), ENT_QUOTES, 'UTF-8');
+        $normalized = str_replace("\xc2\xa0", ' ', $normalized);
+        $normalized = trim($normalized);
+
+        return $normalized === '';
     }
 
     /**

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -908,6 +908,9 @@ class AdminCategoriesControllerCore extends AdminController
             $this->multishopOverwriteData = $this->buildMultishopOverwriteData();
             if (!empty($this->multishopOverwriteData['differences'])) {
                 $this->warnings[] = $this->l('This category already has different text values for some fields in different shops. When editing it in All shops context, please review the differences and decide on the appropriate action.');
+                $this->display = 'edit';
+                $this->id_object = Tools::getIntValue($this->identifier);
+                $this->loadObject(true);
                 return false;
             }
         }

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -1050,7 +1050,7 @@ class AdminCategoriesControllerCore extends AdminController
             $languageNames[(int) $language['id_lang']] = $language['name'];
         }
 
-        $shops = Shop::getShops(true, null, true);
+        $shops = Shop::getShops(true, null, false);
         $shopNames = [];
         foreach ($shops as $shop) {
             $shopNames[(int) $shop['id_shop']] = $shop['name'];

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -544,7 +544,9 @@ class AdminCategoriesControllerCore extends AdminController
         if ($this->shouldCheckMultishopOverwrite() && !$this->getMultishopOverwriteAction()) {
             $overwriteData = $this->buildMultishopOverwriteData();
             if (!empty($overwriteData['differences'])) {
-                $this->warnings[] = $this->l('This category already has different text values for some fields in different shops. When editing it in All shops context, please review the differences and decide on the appropriate action.');
+                $warning = $this->l('This category already has different text values for some fields in different shops. When editing it in All shops context, please review the differences and decide on the appropriate action.');
+                $warning .= $this->formatMultishopOverwriteDifferences($overwriteData['differences']);
+                $this->warnings[] = $warning;
             }
         }
 
@@ -988,6 +990,35 @@ class AdminCategoriesControllerCore extends AdminController
         }
 
         return null;
+    }
+
+    /**
+     * @param array $differences
+     *
+     * @return string
+     */
+    protected function formatMultishopOverwriteDifferences(array $differences): string
+    {
+        if (!$differences) {
+            return '';
+        }
+
+        $lines = ['<ul>'];
+        foreach ($differences as $difference) {
+            $shopName = $difference['shop_name'] ?? '';
+            $lines[] = '<li>'.Tools::safeOutput($shopName);
+            if (!empty($difference['fields'])) {
+                $lines[] = '<ul>';
+                foreach ($difference['fields'] as $field) {
+                    $lines[] = '<li>'.Tools::safeOutput($field).'</li>';
+                }
+                $lines[] = '</ul>';
+            }
+            $lines[] = '</li>';
+        }
+        $lines[] = '</ul>';
+
+        return '<br>'.implode('', $lines);
     }
 
     /**

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -234,17 +234,6 @@ class AdminCategoriesControllerCore extends AdminController
     }
 
     /**
-     * @return void
-     *
-     * @throws PrestaShopException
-     */
-    public function setMedia()
-    {
-        parent::setMedia();
-        $this->addJS(_PS_JS_DIR_.'admin/categories_multishop_overwrite.js');
-    }
-
-    /**
      * @throws PrestaShopException
      * @throws SmartyException
      */
@@ -271,6 +260,7 @@ class AdminCategoriesControllerCore extends AdminController
         parent::setMedia();
         $this->addJqueryUi('ui.widget');
         $this->addJqueryPlugin('tagify');
+        $this->addJS(_PS_JS_DIR_.'admin/categories_multishop_overwrite.js');
     }
 
     /**
@@ -544,6 +534,10 @@ class AdminCategoriesControllerCore extends AdminController
         $obj = $this->loadObject(true);
         if (! $obj) {
             return;
+        }
+
+        if ($this->shouldCheckMultishopOverwrite() && !$this->getMultishopOverwriteAction()) {
+            $this->multishopOverwriteData = $this->buildMultishopOverwriteData();
         }
 
         $context = $this->context;
@@ -910,7 +904,7 @@ class AdminCategoriesControllerCore extends AdminController
         if ($this->shouldCheckMultishopOverwrite() && !$this->multishopOverwriteAction) {
             $this->multishopOverwriteData = $this->buildMultishopOverwriteData();
             if (!empty($this->multishopOverwriteData['differences'])) {
-                $this->warnings[] = $this->l('This category already has different text values for some fields in some shops. When saving, please review the differences and decide on the appropriate action.');
+                $this->warnings[] = $this->l('This category already has different text values for some fields in different shops. When editing it in All shops context, please review the differences and decide on the appropriate action.');
                 return false;
             }
         }

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -537,7 +537,10 @@ class AdminCategoriesControllerCore extends AdminController
         }
 
         if ($this->shouldCheckMultishopOverwrite() && !$this->getMultishopOverwriteAction()) {
-            $this->multishopOverwriteData = $this->buildMultishopOverwriteData();
+            $overwriteData = $this->buildMultishopOverwriteData();
+            if (!empty($overwriteData['differences'])) {
+                $this->warnings[] = $this->l('This category already has different text values for some fields in different shops. When editing it in All shops context, please review the differences and decide on the appropriate action.');
+            }
         }
 
         $context = $this->context;

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -541,7 +541,7 @@ class AdminCategoriesControllerCore extends AdminController
             return;
         }
 
-        if ($this->shouldCheckMultishopOverwrite() && !$this->getMultishopOverwriteAction()) {
+        if ($this->shouldCheckMultishopOverwrite() && !$this->getMultishopOverwriteAction() && !Tools::getIntValue('conf')) {
             $overwriteData = $this->buildMultishopOverwriteData();
             if (!empty($overwriteData['differences'])) {
                 $warning = $this->l('This category already has different text values for some fields in different shops. When editing it in All shops context, please review the differences and decide on the appropriate action.');

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -83,6 +83,11 @@ class AdminCategoriesControllerCore extends AdminController
     protected $multishopOverwriteAction = null;
 
     /**
+     * @var string|null
+     */
+    protected $multishopOverwriteSubmitAction = null;
+
+    /**
      * AdminCategoriesControllerCore constructor.
      *
      * @throws PrestaShopException
@@ -700,6 +705,10 @@ class AdminCategoriesControllerCore extends AdminController
                     'name' => 'category_multishop_overwrite_action',
                 ],
                 [
+                    'type' => 'hidden',
+                    'name' => 'category_multishop_submit_action',
+                ],
+                [
                     'type'              => 'group',
                     'label'             => $this->l('Group access'),
                     'name'              => 'groupBox',
@@ -729,6 +738,10 @@ class AdminCategoriesControllerCore extends AdminController
         $this->tpl_form_vars['shared_category'] = Validate::isLoadedObject($obj) && $obj->hasMultishopEntries();
         $this->tpl_form_vars['PS_ALLOW_ACCENTED_CHARS_URL'] = (int) Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL');
         $this->tpl_form_vars['displayBackOfficeCategory'] = Hook::displayHook('displayBackOfficeCategory');
+
+        if ($this->multishopOverwriteSubmitAction) {
+            $this->fields_value['category_multishop_submit_action'] = $this->multishopOverwriteSubmitAction;
+        }
 
         if ($this->multishopOverwriteData) {
             Media::addJsDef(
@@ -908,6 +921,7 @@ class AdminCategoriesControllerCore extends AdminController
             $this->multishopOverwriteData = $this->buildMultishopOverwriteData();
             if (!empty($this->multishopOverwriteData['differences'])) {
                 $this->warnings[] = $this->l('This category already has different text values for some fields in different shops. When editing it in All shops context, please review the differences and decide on the appropriate action.');
+                $this->multishopOverwriteSubmitAction = $this->getMultishopSubmitActionName();
                 $this->display = 'edit';
                 $this->id_object = Tools::getIntValue($this->identifier);
                 $this->loadObject(true);
@@ -951,6 +965,26 @@ class AdminCategoriesControllerCore extends AdminController
         $action = Tools::getValue('category_multishop_overwrite_action');
         if (in_array($action, [static::MULTISHOP_OVERWRITE_ALL, static::MULTISHOP_OVERWRITE_EMPTY], true)) {
             return $action;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return string|null
+     */
+    protected function getMultishopSubmitActionName()
+    {
+        $submitButtons = [
+            'submitAdd'.$this->table.'AndStay',
+            'submitAdd'.$this->table.'AndBackToParent',
+            'submitAdd'.$this->table,
+        ];
+
+        foreach ($submitButtons as $submitButton) {
+            if (Tools::isSubmit($submitButton)) {
+                return $submitButton;
+            }
         }
 
         return null;

--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -920,7 +920,8 @@ class AdminCategoriesControllerCore extends AdminController
         $this->multishopOverwriteAction = $this->getMultishopOverwriteAction();
 
         if ($this->shouldCheckMultishopOverwrite() && !$this->multishopOverwriteAction) {
-            $this->multishopOverwriteData = $this->buildMultishopOverwriteData();
+            $submittedValues = $this->getSubmittedLangValues(array_keys($this->getMultishopTextFields()));
+            $this->multishopOverwriteData = $this->buildMultishopOverwriteData($submittedValues);
             if (!empty($this->multishopOverwriteData['differences'])) {
                 $this->warnings[] = $this->l('This category already has different text values for some fields in different shops. When editing it in All shops context, please review the differences and decide on the appropriate action.');
                 $this->multishopOverwriteSubmitAction = $this->getMultishopSubmitActionName();
@@ -978,9 +979,9 @@ class AdminCategoriesControllerCore extends AdminController
     protected function getMultishopSubmitActionName()
     {
         $submitButtons = [
-            'submitAdd'.$this->table.'AndStay',
             'submitAdd'.$this->table.'AndBackToParent',
             'submitAdd'.$this->table,
+            'submitAdd'.$this->table.'AndStay',
         ];
 
         foreach ($submitButtons as $submitButton) {
@@ -1100,7 +1101,14 @@ class AdminCategoriesControllerCore extends AdminController
      *
      * @throws PrestaShopException
      */
-    protected function buildMultishopOverwriteData(): array
+    /**
+     * @param array|null $submittedValues
+     *
+     * @return array
+     *
+     * @throws PrestaShopException
+     */
+    protected function buildMultishopOverwriteData(array $submittedValues = null): array
     {
         $idCategory = Tools::getIntValue($this->identifier);
         if (!$idCategory) {
@@ -1111,7 +1119,6 @@ class AdminCategoriesControllerCore extends AdminController
         $fields = $this->getMultishopTextFields();
         $fieldNames = array_keys($fields);
         $storedValues = $this->getCategoryLangValuesByShop($idCategory, $shopIds, $fieldNames);
-        $submittedValues = $this->getSubmittedLangValues($fieldNames);
         $languages = Language::getLanguages(false);
         $languageNames = [];
         foreach ($languages as $language) {
@@ -1126,14 +1133,19 @@ class AdminCategoriesControllerCore extends AdminController
 
         $differences = [];
         $hasMultipleLanguages = count($languages) > 1;
+        $baselineShopId = $shopIds ? (int) reset($shopIds) : null;
         foreach ($shopIds as $shopId) {
             $shopDifferences = [];
             foreach ($languages as $language) {
                 $langId = (int) $language['id_lang'];
                 foreach ($fieldNames as $field) {
                     $storedValue = $storedValues[$shopId][$langId][$field] ?? '';
-                    $submittedValue = $submittedValues[$field][$langId] ?? '';
-                    if ($storedValue !== $submittedValue) {
+                    if ($submittedValues !== null) {
+                        $compareValue = $submittedValues[$field][$langId] ?? '';
+                    } else {
+                        $compareValue = $storedValues[$baselineShopId][$langId][$field] ?? '';
+                    }
+                    if ($storedValue !== $compareValue) {
                         $label = $fields[$field];
                         if ($hasMultipleLanguages) {
                             $label .= ' ('.$languageNames[$langId].')';

--- a/js/admin/categories_multishop_overwrite.js
+++ b/js/admin/categories_multishop_overwrite.js
@@ -21,9 +21,6 @@ $(function () {
       '  <div class="modal-dialog">' +
       '    <div class="modal-content">' +
       '      <div class="modal-header">' +
-      '        <button type="button" class="close" data-dismiss="modal" aria-label="Close">' +
-      '          <span aria-hidden="true">&times;</span>' +
-      '        </button>' +
       '        <h4 class="modal-title"></h4>' +
       '      </div>' +
       '      <div class="modal-body">' +

--- a/js/admin/categories_multishop_overwrite.js
+++ b/js/admin/categories_multishop_overwrite.js
@@ -1,0 +1,91 @@
+$(function () {
+  if (typeof categoryMultishopOverwriteData === 'undefined' || !categoryMultishopOverwriteData) {
+    return;
+  }
+
+  var differences = categoryMultishopOverwriteData.differences || [];
+  if (!differences.length) {
+    return;
+  }
+
+  var $form = $('#category_form');
+  if (!$form.length) {
+    return;
+  }
+
+  var modalId = 'category-multishop-overwrite-modal';
+  var $modal = $('#' + modalId);
+  if (!$modal.length) {
+    var modalHtml = '' +
+      '<div class="modal fade" id="' + modalId + '" tabindex="-1" role="dialog" aria-hidden="true">' +
+      '  <div class="modal-dialog">' +
+      '    <div class="modal-content">' +
+      '      <div class="modal-header">' +
+      '        <button type="button" class="close" data-dismiss="modal" aria-label="Close">' +
+      '          <span aria-hidden="true">&times;</span>' +
+      '        </button>' +
+      '        <h4 class="modal-title"></h4>' +
+      '      </div>' +
+      '      <div class="modal-body">' +
+      '        <p class="category-multishop-overwrite-message"></p>' +
+      '        <div class="category-multishop-overwrite-list"></div>' +
+      '      </div>' +
+      '      <div class="modal-footer">' +
+      '        <button type="button" class="btn btn-default" data-dismiss="modal" id="' + modalId + '-cancel"></button>' +
+      '        <button type="button" class="btn btn-warning" id="' + modalId + '-empty"></button>' +
+      '        <button type="button" class="btn btn-primary" id="' + modalId + '-confirm"></button>' +
+      '      </div>' +
+      '    </div>' +
+      '  </div>' +
+      '</div>';
+    $('body').append(modalHtml);
+    $modal = $('#' + modalId);
+  }
+
+  var escapeHtml = function (value) {
+    return $('<div>').text(value).html();
+  };
+
+  var listHtml = '<ul class="list-unstyled">';
+  $.each(differences, function (index, item) {
+    listHtml += '<li><strong>' + escapeHtml(categoryMultishopOverwriteShopLabel || 'Shop') + ':</strong> ' +
+      escapeHtml(item.shop_name) +
+      '<ul>';
+    $.each(item.fields || [], function (fieldIndex, fieldLabel) {
+      listHtml += '<li>' + escapeHtml(fieldLabel) + '</li>';
+    });
+    listHtml += '</ul></li>';
+  });
+  listHtml += '</ul>';
+
+  $modal.find('.modal-title').text(categoryMultishopOverwriteTitle || '');
+  $modal.find('.category-multishop-overwrite-message').text(categoryMultishopOverwriteMessage || '');
+  $modal.find('.category-multishop-overwrite-list').html(listHtml);
+  $modal.find('#' + modalId + '-confirm').text(categoryMultishopOverwriteConfirmLabel || '');
+  $modal.find('#' + modalId + '-empty').text(categoryMultishopOverwriteEmptyLabel || '');
+  $modal.find('#' + modalId + '-cancel').text(categoryMultishopOverwriteCancelLabel || '');
+
+  var setActionAndSubmit = function (action) {
+    var fieldName = categoryMultishopOverwriteActionField || 'category_multishop_overwrite_action';
+    var $input = $form.find('input[name="' + fieldName + '"]');
+    if (!$input.length) {
+      $input = $('<input type="hidden">').attr('name', fieldName).appendTo($form);
+    }
+    $input.val(action);
+    $form.submit();
+  };
+
+  $modal.find('#' + modalId + '-confirm').off('click').on('click', function () {
+    setActionAndSubmit('overwrite_all');
+  });
+
+  $modal.find('#' + modalId + '-empty').off('click').on('click', function () {
+    setActionAndSubmit('overwrite_empty');
+  });
+
+  $modal.modal({
+    backdrop: 'static',
+    keyboard: false
+  });
+  $modal.modal('show');
+});

--- a/js/admin/categories_multishop_overwrite.js
+++ b/js/admin/categories_multishop_overwrite.js
@@ -69,6 +69,13 @@ $(function () {
       $input = $('<input type="hidden">').attr('name', fieldName).appendTo($form);
     }
     $input.val(action);
+    var submitActionName = $form.find('input[name="category_multishop_submit_action"]').val();
+    if (submitActionName) {
+      var $submitInput = $form.find('input[name="' + submitActionName + '"]');
+      if (!$submitInput.length) {
+        $('<input type="hidden">').attr('name', submitActionName).val('1').appendTo($form);
+      }
+    }
     $form.submit();
   };
 


### PR DESCRIPTION
### Motivation
- Prevent accidental overwrites of per-shop text fields when saving a category in `Shop::CONTEXT_ALL` by detecting differences and prompting the merchant for an action.
- Provide clear choices: overwrite all shops, only populate empty values per shop, or cancel the save to avoid data loss.

### Description
- Add new constants and controller state: `MULTISHOP_OVERWRITE_ALL`, `MULTISHOP_OVERWRITE_EMPTY`, `$multishopOverwriteData`, and `$multishopOverwriteAction` in `AdminCategoriesController`. 
- Load a new admin JS file via `setMedia()` and add a hidden form field `category_multishop_overwrite_action` in the category form; expose modal data to JS using `Media::addJsDef()` when differences are detected. 
- Implement detection and flow in `processUpdate()` so that when editing in all-shops context the controller builds per-shop per-language text field differences and interrupts the save to prompt the user if differences exist. 
- Provide helper methods: `shouldCheckMultishopOverwrite()`, `getMultishopOverwriteAction()`, `getMultishopTextFields()`, `getSubmittedLangValues()`, `getCategoryLangValuesByShop()`, `buildMultishopOverwriteData()`, `restoreCategoryLangValues()` and `isValueEmpty()` to compute differences and to selectively restore values when the merchant chooses `overwrite_empty` (so existing non-empty per-shop values are preserved). 
- Add `js/admin/categories_multishop_overwrite.js` which renders a bootstrap modal listing shops with differing fields and submits the chosen action (`overwrite_all` or `overwrite_empty`) back to the controller or cancels the save.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ad86bcf74832db6cabea7a93037f1)