### PR TITLE
Preserve deferred script attributes in footer output

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -108,6 +108,11 @@ class MediaCore
     protected static $inline_script_src = [];
 
     /**
+     * @var array list of deferred script tags with attributes preserved
+     */
+    protected static $deferred_script_tags = [];
+
+    /**
      * @var string used for preg_replace_callback parameter (avoid global)
      */
     protected static $current_css_file;
@@ -898,6 +903,16 @@ class MediaCore
     }
 
     /**
+     * Get deferred script tags with attributes preserved.
+     *
+     * @return array deferred script tags
+     */
+    public static function getDeferredScriptTags()
+    {
+        return Media::$deferred_script_tags;
+    }
+
+    /**
      * Add a new javascript definition at bottom of page
      *
      * @param string|int|bool|float|array $jsDef
@@ -985,7 +1000,12 @@ class MediaCore
                             }
                         }
                     }
-                    if (!in_array($src, Media::$inline_script_src) && !$script->getAttribute(Media::$pattern_keepinline)) {
+                    $keepInline = $script->getAttribute(Media::$pattern_keepinline);
+                    $preserveAttributes = $script->hasAttribute('async')
+                        || $script->hasAttribute('defer')
+                        || (strtolower($script->getAttribute('type')) === 'module');
+
+                    if (!$preserveAttributes && !in_array($src, Media::$inline_script_src) && !$keepInline) {
                         Context::getContext()->controller->addJS($src);
                     }
                 }
@@ -1019,6 +1039,16 @@ class MediaCore
 
         if (isset($matches[2])) {
             $inline = trim($matches[2]);
+        }
+
+        $keepInline = preg_match('/'.Media::$pattern_keepinline.'/', $original);
+        $preserveAttributes = preg_match('/\basync(\s|=|>)/i', $original)
+            || preg_match('/\bdefer(\s|=|>)/i', $original)
+            || preg_match('/\btype\s*=\s*(["\']?)module\\1/i', $original);
+
+        if ($preserveAttributes && !$keepInline) {
+            Media::$deferred_script_tags[] = $original;
+            return '';
         }
 
         /* This is an inline script, add its content to inline scripts stack then remove it from content */

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -672,6 +672,7 @@ class FrontControllerCore extends Controller
                     'js_def' => Media::getJsDef(),
                     'js_files' => $defer ? array_unique($this->js_files) : [],
                     'js_inline' => ($defer && $domAvailable) ? Media::getInlineScript() : [],
+                    'js_deferred' => ($defer && $domAvailable) ? Media::getDeferredScriptTags() : [],
                 ]
             );
             $javascript = $this->context->smarty->fetch(_PS_ALL_THEMES_DIR_ . 'javascript.tpl');

--- a/themes/javascript.tpl
+++ b/themes/javascript.tpl
@@ -54,6 +54,11 @@ var {$k} = '{$def|@addcslashes:'\''}';
 <script src="{$js_uri}"></script>
 {/foreach}
 {/if}
+{if isset($js_deferred) && $js_deferred|@count}
+{foreach from=$js_deferred key=k item=js_tag}
+{$js_tag}
+{/foreach}
+{/if}
 {if isset($js_inline) && $js_inline|@count}
 <script>
 {foreach from=$js_inline key=k item=inline}


### PR DESCRIPTION
### Motivation
- When JavaScript is moved to the end (deferred), script tags that used `async`, `defer`, or `type="module"` were being stripped; preserve those original tags so attributes and module semantics are not lost.

### Description
- Add a new `protected static $deferred_script_tags` storage and accessor `Media::getDeferredScriptTags()` to capture script tags that must keep attributes. 
- Detect attribute-bearing tags (`async`, `defer`, `type="module"`) in `Media::deferInlineScripts()` and `Media::deferScript()` and store the original tag instead of pushing them through the normal `js_files` flow. 
- Expose the captured tags to templates by assigning `js_deferred` in `FrontController::getSmartyOutputContent()` and render them in `themes/javascript.tpl` so the original tags are emitted unchanged in the footer.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738abb992c832dadca55240cebdb94)