### PR TITLE
Preserve script attributes when deferring JS

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -108,6 +108,11 @@ class MediaCore
     protected static $inline_script_src = [];
 
     /**
+     * @var array list of javascript external scripts attributes (deferred)
+     */
+    protected static $defer_script_attributes = [];
+
+    /**
      * @var string used for preg_replace_callback parameter (avoid global)
      */
     protected static $current_css_file;
@@ -898,6 +903,16 @@ class MediaCore
     }
 
     /**
+     * Get script attributes for deferred external scripts.
+     *
+     * @return array
+     */
+    public static function getDeferredScriptAttributes()
+    {
+        return Media::$defer_script_attributes;
+    }
+
+    /**
      * Add a new javascript definition at bottom of page
      *
      * @param string|int|bool|float|array $jsDef
@@ -986,6 +1001,10 @@ class MediaCore
                         }
                     }
                     if (!in_array($src, Media::$inline_script_src) && !$script->getAttribute(Media::$pattern_keepinline)) {
+                        $attributes = Media::getScriptAttributesFromDom($script);
+                        if (!empty($attributes) && !isset(Media::$defer_script_attributes[$src])) {
+                            Media::$defer_script_attributes[$src] = Media::formatScriptAttributes($attributes);
+                        }
                         Context::getContext()->controller->addJS($src);
                     }
                 }
@@ -1022,7 +1041,16 @@ class MediaCore
         }
 
         /* This is an inline script, add its content to inline scripts stack then remove it from content */
-        if (!empty($inline) && preg_match(Media::$pattern_js, $original) !== false && !preg_match('/'.Media::$pattern_keepinline.'/', $original) && Media::$inline_script[] = $inline) {
+        if (!empty($inline) && preg_match(Media::$pattern_js, $original) !== false && !preg_match('/'.Media::$pattern_keepinline.'/', $original)) {
+            $attributes = Media::getScriptAttributesFromTag($original);
+            if (!empty($attributes)) {
+                Media::$inline_script[] = [
+                    'content' => $inline,
+                    'attributes' => Media::formatScriptAttributes($attributes),
+                ];
+            } else {
+                Media::$inline_script[] = $inline;
+            }
             return '';
         }
         /* This is an external script, if it already belongs to js_files then remove it from content */
@@ -1041,6 +1069,90 @@ class MediaCore
         /* return original string because no match was found */
 
         return "\n".$original;
+    }
+
+    /**
+     * Extract script attributes from DOMElement.
+     *
+     * @param DOMElement $script
+     *
+     * @return array
+     */
+    protected static function getScriptAttributesFromDom(DOMElement $script)
+    {
+        $attributes = [];
+        if ($script->hasAttribute('async')) {
+            $attributes['async'] = true;
+        }
+        if ($script->hasAttribute('defer')) {
+            $attributes['defer'] = true;
+        }
+        if ($script->hasAttribute('type')) {
+            $type = trim($script->getAttribute('type'));
+            if ($type !== '') {
+                $attributes['type'] = $type;
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Extract script attributes from script tag.
+     *
+     * @param string $scriptTag
+     *
+     * @return array
+     */
+    protected static function getScriptAttributesFromTag($scriptTag)
+    {
+        $attributes = [];
+        if (!preg_match('/<\s*script\b([^>]*)>/i', $scriptTag, $matches)) {
+            return $attributes;
+        }
+
+        $attrString = $matches[1];
+        if (preg_match('/\basync\b/i', $attrString)) {
+            $attributes['async'] = true;
+        }
+        if (preg_match('/\bdefer\b/i', $attrString)) {
+            $attributes['defer'] = true;
+        }
+        if (preg_match('/\btype\s*=\s*(["\']?)([^\s"\'>]+)\1/i', $attrString, $typeMatch)) {
+            $type = trim($typeMatch[2]);
+            if ($type !== '') {
+                $attributes['type'] = $type;
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Format script attributes for output.
+     *
+     * @param array $attributes
+     *
+     * @return string
+     */
+    protected static function formatScriptAttributes(array $attributes)
+    {
+        $parts = [];
+        if (!empty($attributes['async'])) {
+            $parts[] = 'async';
+        }
+        if (!empty($attributes['defer'])) {
+            $parts[] = 'defer';
+        }
+        if (!empty($attributes['type'])) {
+            $parts[] = 'type="'.htmlspecialchars($attributes['type'], ENT_QUOTES, 'UTF-8').'"';
+        }
+
+        if (!$parts) {
+            return '';
+        }
+
+        return ' '.implode(' ', $parts);
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -671,6 +671,7 @@ class FrontControllerCore extends Controller
                 [
                     'js_def' => Media::getJsDef(),
                     'js_files' => $defer ? array_unique($this->js_files) : [],
+                    'js_files_attributes' => ($defer && $domAvailable) ? Media::getDeferredScriptAttributes() : [],
                     'js_inline' => ($defer && $domAvailable) ? Media::getInlineScript() : [],
                 ]
             );

--- a/themes/javascript.tpl
+++ b/themes/javascript.tpl
@@ -51,13 +51,23 @@ var {$k} = '{$def|@addcslashes:'\''}';
 {/if}
 {if isset($js_files) && $js_files|@count}
 {foreach from=$js_files key=k item=js_uri}
-<script src="{$js_uri}"></script>
+{assign var=js_attributes value=''}
+{if isset($js_files_attributes[$js_uri])}
+{assign var=js_attributes value=$js_files_attributes[$js_uri]}
+{/if}
+<script src="{$js_uri}"{$js_attributes}></script>
 {/foreach}
 {/if}
 {if isset($js_inline) && $js_inline|@count}
-<script>
 {foreach from=$js_inline key=k item=inline}
-{$inline}
-{/foreach}
+{if is_array($inline)}
+<script{$inline.attributes|default:''}>
+{$inline.content}
 </script>
+{else}
+<script>
+{$inline}
+</script>
+{/if}
+{/foreach}
 {/if}


### PR DESCRIPTION
### Motivation
- When the "move JavaScript to the end" (defer) option is enabled, script attributes such as `async`, `defer` and `type` (including `type="module"`) were being lost, changing runtime behavior of deferred scripts.
- The change aims to keep the existing behavior of moving scripts to the end while preserving their original attributes so deferred scripts execute correctly.

### Description
- Added storage for deferred script attribute metadata with `protected static $defer_script_attributes` and accessor `getDeferredScriptAttributes()` in `classes/Media.php`.
- Captured attributes from DOM `script` elements and from raw script tags via `getScriptAttributesFromDom()` and `getScriptAttributesFromTag()`, and formatted them for output with `formatScriptAttributes()`.
- When deferring, external script attributes are recorded and `Context::getContext()->controller->addJS()` is still used to queue the file; inline scripts are stored as either raw strings or arrays with `content` and `attributes` so attributes are preserved.
- Passed attribute metadata to the template in `classes/controller/FrontController.php` as `js_files_attributes`, and updated `themes/javascript.tpl` to render external scripts with their attributes and inline scripts with preserved attributes (including rendering `type="module"`, `async`, `defer`, etc.).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738abb992c832dadca55240cebdb94)