### PR TITLE
Preserve deferred script attributes when moving JS to footer

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -108,6 +108,11 @@ class MediaCore
     protected static $inline_script_src = [];
 
     /**
+     * @var array list of deferred script attributes keyed by script src
+     */
+    protected static $deferred_script_attributes = [];
+
+    /**
      * @var string used for preg_replace_callback parameter (avoid global)
      */
     protected static $current_css_file;
@@ -898,6 +903,16 @@ class MediaCore
     }
 
     /**
+     * Get deferred script attributes keyed by script src
+     *
+     * @return array
+     */
+    public static function getDeferredScriptAttributes()
+    {
+        return Media::$deferred_script_attributes;
+    }
+
+    /**
      * Add a new javascript definition at bottom of page
      *
      * @param string|int|bool|float|array $jsDef
@@ -986,6 +1001,28 @@ class MediaCore
                         }
                     }
                     if (!in_array($src, Media::$inline_script_src) && !$script->getAttribute(Media::$pattern_keepinline)) {
+                        $attributes = [];
+                        if ($script->hasAttribute('async')) {
+                            $attributes['async'] = true;
+                        }
+                        if ($script->hasAttribute('defer')) {
+                            $attributes['defer'] = true;
+                        }
+                        if ($script->hasAttribute('type')) {
+                            $type = trim($script->getAttribute('type'));
+                            if ($type !== '') {
+                                $attributes['type'] = $type;
+                            }
+                        }
+                        if (!empty($attributes)) {
+                            if (!isset(Media::$deferred_script_attributes[$src])) {
+                                Media::$deferred_script_attributes[$src] = [];
+                            }
+                            Media::$deferred_script_attributes[$src] = array_merge(
+                                Media::$deferred_script_attributes[$src],
+                                $attributes
+                            );
+                        }
                         Context::getContext()->controller->addJS($src);
                     }
                 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -671,6 +671,7 @@ class FrontControllerCore extends Controller
                 [
                     'js_def' => Media::getJsDef(),
                     'js_files' => $defer ? array_unique($this->js_files) : [],
+                    'js_files_attrs' => $defer ? Media::getDeferredScriptAttributes() : [],
                     'js_inline' => ($defer && $domAvailable) ? Media::getInlineScript() : [],
                 ]
             );

--- a/themes/javascript.tpl
+++ b/themes/javascript.tpl
@@ -51,7 +51,7 @@ var {$k} = '{$def|@addcslashes:'\''}';
 {/if}
 {if isset($js_files) && $js_files|@count}
 {foreach from=$js_files key=k item=js_uri}
-<script src="{$js_uri}"></script>
+<script src="{$js_uri}"{if isset($js_files_attrs) && isset($js_files_attrs[$js_uri])}{foreach from=$js_files_attrs[$js_uri] key=attr item=attrValue}{if is_bool($attrValue)} {$attr}{elseif $attrValue ne ''} {$attr}="{$attrValue|escape:'htmlall':'UTF-8'}"{/if}{/foreach}{/if}></script>
 {/foreach}
 {/if}
 {if isset($js_inline) && $js_inline|@count}


### PR DESCRIPTION
### Motivation
- When "Move JavaScript to the end" (`PS_JS_DEFER`) was enabled, script attributes such as `async`, `defer` and `type` (for example `type="module"`) were lost when inline/external scripts were deferred to the footer.
- The goal is to keep the current behavior of moving scripts to the end while preserving those attributes so moved scripts keep their original loading semantics.

### Description
- Added a new internal storage `Media::$deferred_script_attributes` and accessor `Media::getDeferredScriptAttributes()` to track attributes keyed by script `src`.
- Updated `Media::deferInlineScripts()` to collect `async`, `defer` and non-empty `type` attributes for external scripts before enqueuing them via `Context::getContext()->controller->addJS()`.
- Exposed the collected attributes to templates by adding the `js_files_attrs` assignment in `FrontController::getSmartyOutputContent()` when deferring is active.
- Updated `themes/javascript.tpl` to render preserved attributes for each deferred `<script src="...">`, outputting boolean attributes (like `async`/`defer`) as standalone and other attributes (like `type`) as `name="value"` with HTML escaping.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738abb992c832dadca55240cebdb94)