### PR TITLE
Rename Kiev timezone references to Kyiv in core data

### DIFF
--- a/install-dev/data/iso_to_timezone.xml
+++ b/install-dev/data/iso_to_timezone.xml
@@ -175,7 +175,7 @@
 	<relation iso="im" zone="Europe/Isle_of_Man" />
 	<relation iso="tr" zone="Europe/Istanbul" />
 	<relation iso="je" zone="Europe/Jersey" />
-	<relation iso="ua" zone="Europe/Kiev" />
+	<relation iso="ua" zone="Europe/Kyiv" />
 	<relation iso="pt" zone="Europe/Lisbon" />
 	<relation iso="si" zone="Europe/Ljubljana" />
 	<relation iso="gb" zone="Europe/London" />

--- a/install-dev/data/xml/timezone.xml
+++ b/install-dev/data/xml/timezone.xml
@@ -364,7 +364,7 @@
     <timezone id="Europe_Istanbul" name="Europe/Istanbul"/>
     <timezone id="Europe_Jersey" name="Europe/Jersey"/>
     <timezone id="Europe_Kaliningrad" name="Europe/Kaliningrad"/>
-    <timezone id="Europe_Kiev" name="Europe/Kiev"/>
+    <timezone id="Europe_Kyiv" name="Europe/Kyiv"/>
     <timezone id="Europe_Lisbon" name="Europe/Lisbon"/>
     <timezone id="Europe_Ljubljana" name="Europe/Ljubljana"/>
     <timezone id="Europe_London" name="Europe/London"/>


### PR DESCRIPTION
### Motivation
- Replace deprecated `Kiev` timezone identifiers with the modern `Kyiv` form in installer core data to ensure correct/updated timezone naming.

### Description
- Updated `install-dev/data/iso_to_timezone.xml` relation for `iso="ua"` from `Europe/Kiev` to `Europe/Kyiv` and updated `install-dev/data/xml/timezone.xml` timezone `id`/`name` from `Europe_Kiev`/`Europe/Kiev` to `Europe_Kyiv`/`Europe/Kyiv`.

### Testing
- Ran `rg -n "Kiev|Europe/Kiev|Europe_Kiev" /workspace/thirtybees` and confirmed there are no remaining legacy matches (success).
- Verified the updated entries exist with `rg -n "Kyiv|Europe/Kyiv|Europe_Kyiv" install-dev/data/iso_to_timezone.xml install-dev/data/xml/timezone.xml` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af33f797c832da25dfc11bb66932e)