### PR TITLE
Allow partial reorder duplication when some products are unavailable

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4455,6 +4455,8 @@ class CartCore extends ObjectModel
 
         $conn = Db::getInstance();
         $success = true;
+        $unavailableProducts = [];
+        $duplicatedProducts = [];
         $products = $conn->getArray(
             (new DbQuery())
                 ->select('*')
@@ -4485,7 +4487,7 @@ class CartCore extends ObjectModel
                 }
             }
 
-            $success = $cart->updateQty(
+            $updated = $cart->updateQty(
                 (int) $product['quantity'],
                 (int) $product['id_product'],
                 (int) $product['id_product_attribute'],
@@ -4494,7 +4496,17 @@ class CartCore extends ObjectModel
                 (int) $idAddressDelivery,
                 new Shop((int) $cart->id_shop),
                 false
-            ) && $success;
+            );
+
+            if ($updated) {
+                $duplicatedProducts[(int) $product['id_product'].':'.(int) $product['id_product_attribute']] = true;
+            } else {
+                $success = false;
+                $name = Product::getProductName((int) $product['id_product'], (int) $product['id_product_attribute']);
+                if ($name) {
+                    $unavailableProducts[$name] = $name;
+                }
+            }
         }
 
         // Customized products
@@ -4510,6 +4522,11 @@ class CartCore extends ObjectModel
         $customsById = [];
         foreach ($customs as $custom) {
             if (!isset($customsById[$custom['id_customization']])) {
+                $productKey = (int) $custom['id_product'].':'.(int) $custom['id_product_attribute'];
+                if (!isset($duplicatedProducts[$productKey])) {
+                    continue;
+                }
+
                 $customsById[$custom['id_customization']] = [
                     'id_product_attribute' => $custom['id_product_attribute'],
                     'id_product'           => $custom['id_product'],
@@ -4540,6 +4557,10 @@ class CartCore extends ObjectModel
         // Insert customized_data
         if (count($customs)) {
             foreach ($customs as $custom) {
+                if (!isset($customIds[$custom['id_customization']])) {
+                    continue;
+                }
+
                 $customizedValue = $custom['value'];
 
                 if ((int) $custom['type'] === Product::CUSTOMIZE_FILE) {
@@ -4557,7 +4578,11 @@ class CartCore extends ObjectModel
             }
         }
 
-        return ['cart' => $cart, 'success' => $success];
+        return [
+            'cart'                 => $cart,
+            'success'              => $success,
+            'unavailable_products' => array_values($unavailableProducts),
+        ];
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4487,6 +4487,10 @@ class CartCore extends ObjectModel
                 }
             }
 
+            if ((int) $product['quantity'] <= 0) {
+                continue;
+            }
+
             $updated = $cart->updateQty(
                 (int) $product['quantity'],
                 (int) $product['id_product'],
@@ -4503,9 +4507,15 @@ class CartCore extends ObjectModel
             } else {
                 $success = false;
                 $name = Product::getProductName((int) $product['id_product'], (int) $product['id_product_attribute']);
-                if ($name) {
-                    $unavailableProducts[$name] = $name;
+                if (!$name) {
+                    $name = sprintf(
+                        'Product #%d%s',
+                        (int) $product['id_product'],
+                        (int) $product['id_product_attribute'] ? '/'.(int) $product['id_product_attribute'] : ''
+                    );
                 }
+
+                $unavailableProducts[$name] = $name;
             }
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4487,10 +4487,6 @@ class CartCore extends ObjectModel
                 }
             }
 
-            if ((int) $product['quantity'] <= 0) {
-                continue;
-            }
-
             $updated = $cart->updateQty(
                 (int) $product['quantity'],
                 (int) $product['id_product'],
@@ -4507,15 +4503,9 @@ class CartCore extends ObjectModel
             } else {
                 $success = false;
                 $name = Product::getProductName((int) $product['id_product'], (int) $product['id_product_attribute']);
-                if (!$name) {
-                    $name = sprintf(
-                        'Product #%d%s',
-                        (int) $product['id_product'],
-                        (int) $product['id_product_attribute'] ? '/'.(int) $product['id_product_attribute'] : ''
-                    );
+                if ($name) {
+                    $unavailableProducts[$name] = $name;
                 }
-
-                $unavailableProducts[$name] = $name;
             }
         }
 

--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -109,18 +109,31 @@ class ParentOrderControllerCore extends FrontController
             $duplication = $oldCart->duplicate();
             if (!$duplication || !Validate::isLoadedObject($duplication['cart'])) {
                 $this->errors[] = Tools::displayError('Sorry. We cannot renew your order.');
-            } elseif (!$duplication['success']) {
-                $this->errors[] = Tools::displayError('Some items are no longer available, and we are unable to renew your order.');
             } else {
                 $this->context->cookie->id_cart = $duplication['cart']->id;
                 $context = $this->context;
                 $context->cart = $duplication['cart'];
                 CartRule::autoAddToCart($context);
+                if (!empty($duplication['unavailable_products'])) {
+                    $this->context->cookie->reorder_unavailable_products = implode('|', $duplication['unavailable_products']);
+                }
                 $this->context->cookie->write();
                 if (Configuration::get('PS_ORDER_PROCESS_TYPE') == 1) {
                     Tools::redirect('index.php?controller=order-opc');
                 }
                 Tools::redirect('index.php?controller=order');
+            }
+        }
+
+        if (!empty($this->context->cookie->reorder_unavailable_products)) {
+            $unavailableProducts = array_filter(array_unique(explode('|', (string) $this->context->cookie->reorder_unavailable_products)));
+            unset($this->context->cookie->reorder_unavailable_products);
+
+            if ($unavailableProducts) {
+                $this->errors[] = sprintf(
+                    Tools::displayError('Some items are no longer available and have not been included in your new order: %s'),
+                    implode(', ', $unavailableProducts)
+                );
             }
         }
 

--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -115,7 +115,7 @@ class ParentOrderControllerCore extends FrontController
                 $context->cart = $duplication['cart'];
                 CartRule::autoAddToCart($context);
                 if (!empty($duplication['unavailable_products'])) {
-                    $this->context->cookie->reorder_unavailable_products = json_encode(array_values($duplication['unavailable_products']));
+                    $this->context->cookie->reorder_unavailable_products = implode('|', $duplication['unavailable_products']);
                 }
                 $this->context->cookie->write();
                 if (Configuration::get('PS_ORDER_PROCESS_TYPE') == 1) {
@@ -126,14 +126,9 @@ class ParentOrderControllerCore extends FrontController
         }
 
         if (!empty($this->context->cookie->reorder_unavailable_products)) {
-            $unavailableProducts = json_decode((string) $this->context->cookie->reorder_unavailable_products, true);
+            $unavailableProducts = array_filter(array_unique(explode('|', (string) $this->context->cookie->reorder_unavailable_products)));
             unset($this->context->cookie->reorder_unavailable_products);
 
-            if (!is_array($unavailableProducts)) {
-                $unavailableProducts = [];
-            }
-
-            $unavailableProducts = array_values(array_filter(array_unique($unavailableProducts)));
             if ($unavailableProducts) {
                 $this->errors[] = sprintf(
                     Tools::displayError('Some items are no longer available and have not been included in your new order: %s'),

--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -115,7 +115,7 @@ class ParentOrderControllerCore extends FrontController
                 $context->cart = $duplication['cart'];
                 CartRule::autoAddToCart($context);
                 if (!empty($duplication['unavailable_products'])) {
-                    $this->context->cookie->reorder_unavailable_products = implode('|', $duplication['unavailable_products']);
+                    $this->context->cookie->reorder_unavailable_products = json_encode(array_values($duplication['unavailable_products']));
                 }
                 $this->context->cookie->write();
                 if (Configuration::get('PS_ORDER_PROCESS_TYPE') == 1) {
@@ -126,9 +126,14 @@ class ParentOrderControllerCore extends FrontController
         }
 
         if (!empty($this->context->cookie->reorder_unavailable_products)) {
-            $unavailableProducts = array_filter(array_unique(explode('|', (string) $this->context->cookie->reorder_unavailable_products)));
+            $unavailableProducts = json_decode((string) $this->context->cookie->reorder_unavailable_products, true);
             unset($this->context->cookie->reorder_unavailable_products);
 
+            if (!is_array($unavailableProducts)) {
+                $unavailableProducts = [];
+            }
+
+            $unavailableProducts = array_values(array_filter(array_unique($unavailableProducts)));
             if ($unavailableProducts) {
                 $this->errors[] = sprintf(
                     Tools::displayError('Some items are no longer available and have not been included in your new order: %s'),


### PR DESCRIPTION
### Motivation
- Reordering a past order currently fails when one or more products are disabled or deleted, preventing customers from re-adding the remaining available items.

### Description
- Updated `Cart::duplicate()` to attempt to re-add each product individually and continue when some `updateQty()` calls fail, while collecting unavailable product names via `Product::getProductName()` and returning them in the duplication result under `unavailable_products`.
- Ensured customizations are only copied for products that were successfully duplicated by skipping customization rows for products that failed to duplicate.
- Updated `ParentOrderController` reorder flow to set the new cart even when some products were skipped, persist the list of skipped product names in `cookie->reorder_unavailable_products` across the redirect, and display a warning message listing skipped products on the next request.

### Testing
- Syntax checks: `php -l classes/Cart.php` (passed) and `php -l controllers/front/ParentOrderController.php` (passed).
- Verified the reorder flow now creates a new cart when some products are unavailable and surfaces a user-facing warning listing the excluded products (manual flow validation during development).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b956d2170832d924ec12abc6647e1)